### PR TITLE
Add catalog lookup helpers

### DIFF
--- a/catalog/doc.go
+++ b/catalog/doc.go
@@ -1,6 +1,7 @@
 // Package catalog assembles the full Animal Crossing character dataset into
 // backend-friendly read-only registries without changing the underlying domain
-// model packages.
+// model packages. It also provides exact-match, animal-scoped lookup helpers
+// over those registries.
 //
 // The catalog remains grouped by animal because character keys are not
 // guaranteed to be globally unique across the full dataset.

--- a/catalog/lookup.go
+++ b/catalog/lookup.go
@@ -1,0 +1,33 @@
+package catalog
+
+import "github.com/lindsaygelle/nook"
+
+// ResidentsByAnimal returns the resident catalog bucket for an animal key.
+func ResidentsByAnimal(animalKey nook.Key) (nook.Residents, bool) {
+	residents, ok := AllResidents[animalKey]
+	return residents, ok
+}
+
+// VillagersByAnimal returns the villager catalog bucket for an animal key.
+func VillagersByAnimal(animalKey nook.Key) (nook.Villagers, bool) {
+	villagers, ok := AllVillagers[animalKey]
+	return villagers, ok
+}
+
+// ResidentByKey returns a resident from the given animal bucket using an exact key match.
+func ResidentByKey(animalKey, key nook.Key) (nook.Resident, bool) {
+	residents, ok := ResidentsByAnimal(animalKey)
+	if !ok {
+		return nook.Resident{}, false
+	}
+	return residents.Get(key)
+}
+
+// VillagerByKey returns a villager from the given animal bucket using an exact key match.
+func VillagerByKey(animalKey, key nook.Key) (nook.Villager, bool) {
+	villagers, ok := VillagersByAnimal(animalKey)
+	if !ok {
+		return nook.Villager{}, false
+	}
+	return villagers.Get(key)
+}

--- a/catalog/lookup_test.go
+++ b/catalog/lookup_test.go
@@ -1,0 +1,63 @@
+package catalog_test
+
+import (
+	"testing"
+
+	"github.com/lindsaygelle/nook/animal"
+	"github.com/lindsaygelle/nook/catalog"
+	"github.com/lindsaygelle/nook/character"
+	mousecharacters "github.com/lindsaygelle/nook/character/mouse"
+	rabbitcharacters "github.com/lindsaygelle/nook/character/rabbit"
+	raccooncharacters "github.com/lindsaygelle/nook/character/raccoon"
+)
+
+func TestVillagersByAnimal(t *testing.T) {
+	villagers, ok := catalog.VillagersByAnimal(animal.Rabbit.Key)
+	if !ok {
+		t.Fatalf("catalog.VillagersByAnimal(%s) not found", animal.Rabbit.Key)
+	}
+	if len(villagers) != len(rabbitcharacters.Villagers) {
+		t.Fatalf("catalog.VillagersByAnimal(%s) length = %d", animal.Rabbit.Key, len(villagers))
+	}
+}
+
+func TestResidentByKey(t *testing.T) {
+	resident, ok := catalog.ResidentByKey(animal.Raccoon.Key, character.TomNook)
+	if !ok {
+		t.Fatalf("catalog.ResidentByKey(%s, %s) not found", animal.Raccoon.Key, character.TomNook)
+	}
+	if resident.Key != raccooncharacters.TomNook.Key {
+		t.Fatalf("catalog.ResidentByKey(%s, %s).Key = %s", animal.Raccoon.Key, character.TomNook, resident.Key)
+	}
+}
+
+func TestVillagerByKeyUsesAnimalScope(t *testing.T) {
+	rabbitCarmen, ok := catalog.VillagerByKey(animal.Rabbit.Key, character.Carmen)
+	if !ok {
+		t.Fatalf("catalog.VillagerByKey(%s, %s) not found", animal.Rabbit.Key, character.Carmen)
+	}
+	if rabbitCarmen.Code.Value != rabbitcharacters.Carmen.Code.Value {
+		t.Fatalf("catalog.VillagerByKey(%s, %s).Code = %s", animal.Rabbit.Key, character.Carmen, rabbitCarmen.Code.Value)
+	}
+
+	mouseCarmen, ok := catalog.VillagerByKey(animal.Mouse.Key, character.Carmen)
+	if !ok {
+		t.Fatalf("catalog.VillagerByKey(%s, %s) not found", animal.Mouse.Key, character.Carmen)
+	}
+	if mouseCarmen.Code.Value != mousecharacters.Carmen.Code.Value {
+		t.Fatalf("catalog.VillagerByKey(%s, %s).Code = %s", animal.Mouse.Key, character.Carmen, mouseCarmen.Code.Value)
+	}
+
+	if _, ok := catalog.VillagerByKey(animal.Cat.Key, character.Carmen); ok {
+		t.Fatalf("catalog.VillagerByKey(%s, %s) unexpectedly found a villager", animal.Cat.Key, character.Carmen)
+	}
+}
+
+func TestMissingAnimalBucket(t *testing.T) {
+	if _, ok := catalog.VillagersByAnimal("missing"); ok {
+		t.Fatal("catalog.VillagersByAnimal(missing) unexpectedly found a bucket")
+	}
+	if _, ok := catalog.ResidentsByAnimal("missing"); ok {
+		t.Fatal("catalog.ResidentsByAnimal(missing) unexpectedly found a bucket")
+	}
+}


### PR DESCRIPTION
## Summary
- add exact-match, animal-scoped lookup helpers to the catalog package
- cover catalog lookups with public API tests, including shared keys like Carmen across species
- keep the lookup surface narrow and deterministic for backend callers

## Verification
- go test ./...