### PR TITLE
Add catalog record helpers

### DIFF
--- a/catalog/doc.go
+++ b/catalog/doc.go
@@ -1,7 +1,8 @@
 // Package catalog assembles the full Animal Crossing character dataset into
 // backend-friendly read-only registries without changing the underlying domain
 // model packages. It also provides exact-match, animal-scoped lookup helpers
-// over those registries.
+// over those registries, plus small DTO conversion helpers for transport-facing
+// callers.
 //
 // The catalog remains grouped by animal because character keys are not
 // guaranteed to be globally unique across the full dataset.

--- a/catalog/record.go
+++ b/catalog/record.go
@@ -1,0 +1,81 @@
+package catalog
+
+import "github.com/lindsaygelle/nook"
+
+// LocalizedValues is an API-facing representation of localized strings keyed by
+// BCP 47 language tag.
+type LocalizedValues map[string]string
+
+// BirthdayRecord is a transport-friendly birthday representation.
+type BirthdayRecord struct {
+	Day   uint8 `json:"day"`
+	Month uint8 `json:"month"`
+}
+
+// CharacterRecord is a flattened API-facing representation of a character.
+type CharacterRecord struct {
+	AnimalKey string          `json:"animal_key"`
+	Birthday  BirthdayRecord  `json:"birthday"`
+	Code      string          `json:"code,omitempty"`
+	Gender    LocalizedValues `json:"gender"`
+	Key       string          `json:"key"`
+	Name      LocalizedValues `json:"name"`
+	Special   bool            `json:"special"`
+}
+
+// ResidentRecord is an API-facing representation of a resident.
+type ResidentRecord struct {
+	CharacterRecord
+}
+
+// VillagerRecord is an API-facing representation of a villager.
+type VillagerRecord struct {
+	CharacterRecord
+	Personality LocalizedValues `json:"personality"`
+	Phrase      LocalizedValues `json:"phrase"`
+}
+
+// LocalizedValuesOf converts language-tagged values into a transport-friendly
+// map and omits empty values.
+func LocalizedValuesOf(values nook.Languages) LocalizedValues {
+	out := make(LocalizedValues, len(values))
+	for tag, name := range values {
+		if !name.Ok() {
+			continue
+		}
+		out[tag.String()] = name.Value
+	}
+	return out
+}
+
+// CharacterRecordOf converts a domain character into its API-facing record.
+func CharacterRecordOf(character nook.Character) CharacterRecord {
+	return CharacterRecord{
+		AnimalKey: string(character.Animal.Key),
+		Birthday: BirthdayRecord{
+			Day:   character.Birthday.Day,
+			Month: uint8(character.Birthday.Month),
+		},
+		Code:    character.Code.Value,
+		Gender:  LocalizedValuesOf(character.Gender.Name),
+		Key:     string(character.Key),
+		Name:    LocalizedValuesOf(character.Name),
+		Special: character.Special,
+	}
+}
+
+// ResidentRecordOf converts a domain resident into its API-facing record.
+func ResidentRecordOf(resident nook.Resident) ResidentRecord {
+	return ResidentRecord{
+		CharacterRecord: CharacterRecordOf(resident.Character),
+	}
+}
+
+// VillagerRecordOf converts a domain villager into its API-facing record.
+func VillagerRecordOf(villager nook.Villager) VillagerRecord {
+	return VillagerRecord{
+		CharacterRecord: CharacterRecordOf(villager.Character),
+		Personality:     LocalizedValuesOf(villager.Personality.Name),
+		Phrase:          LocalizedValuesOf(villager.Phrase),
+	}
+}

--- a/catalog/record_test.go
+++ b/catalog/record_test.go
@@ -1,0 +1,65 @@
+package catalog_test
+
+import (
+	"testing"
+
+	"github.com/lindsaygelle/nook/animal"
+	"github.com/lindsaygelle/nook/catalog"
+	"github.com/lindsaygelle/nook/character/cat"
+	"github.com/lindsaygelle/nook/character/mouse"
+	"github.com/lindsaygelle/nook/character/raccoon"
+	"golang.org/x/text/language"
+)
+
+func TestCharacterRecordOf(t *testing.T) {
+	record := catalog.CharacterRecordOf(cat.Ankha.Character)
+
+	if record.AnimalKey != string(animal.Cat.Key) {
+		t.Fatalf("catalog.CharacterRecordOf(cat.Ankha).AnimalKey = %s", record.AnimalKey)
+	}
+	if record.Key != "Ankha" {
+		t.Fatalf("catalog.CharacterRecordOf(cat.Ankha).Key = %s", record.Key)
+	}
+	if record.Birthday.Day != 22 || record.Birthday.Month != 9 {
+		t.Fatalf("catalog.CharacterRecordOf(cat.Ankha).Birthday = %#v", record.Birthday)
+	}
+	if record.Name[language.AmericanEnglish.String()] != "Ankha" {
+		t.Fatalf("catalog.CharacterRecordOf(cat.Ankha).Name[en-US] = %s", record.Name[language.AmericanEnglish.String()])
+	}
+}
+
+func TestVillagerRecordOf(t *testing.T) {
+	record := catalog.VillagerRecordOf(cat.Ankha)
+
+	if record.Special {
+		t.Fatal("catalog.VillagerRecordOf(cat.Ankha).Special unexpectedly true")
+	}
+	if record.Personality[language.AmericanEnglish.String()] != "Snooty" {
+		t.Fatalf("catalog.VillagerRecordOf(cat.Ankha).Personality[en-US] = %s", record.Personality[language.AmericanEnglish.String()])
+	}
+	if record.Phrase[language.AmericanEnglish.String()] != "me meow" {
+		t.Fatalf("catalog.VillagerRecordOf(cat.Ankha).Phrase[en-US] = %s", record.Phrase[language.AmericanEnglish.String()])
+	}
+}
+
+func TestResidentRecordOf(t *testing.T) {
+	record := catalog.ResidentRecordOf(raccoon.TomNook)
+
+	if !record.Special {
+		t.Fatal("catalog.ResidentRecordOf(raccoon.TomNook).Special unexpectedly false")
+	}
+	if record.Code != "rcn/rco" {
+		t.Fatalf("catalog.ResidentRecordOf(raccoon.TomNook).Code = %s", record.Code)
+	}
+}
+
+func TestLocalizedValuesOfOmitsEmptyValues(t *testing.T) {
+	values := catalog.LocalizedValuesOf(mouse.Carmen.Name)
+
+	if values[language.AmericanEnglish.String()] != "Carmen" {
+		t.Fatalf("catalog.LocalizedValuesOf(mouse.Carmen.Name)[en-US] = %s", values[language.AmericanEnglish.String()])
+	}
+	if _, ok := values[language.CanadianFrench.String()]; ok {
+		t.Fatal("catalog.LocalizedValuesOf(mouse.Carmen.Name) unexpectedly included an empty value")
+	}
+}


### PR DESCRIPTION
## Summary
- add transport-facing catalog record types for characters, villagers, and residents
- add conversion helpers that flatten the domain model into JSON-friendly shapes
- omit empty localized values from record output and cover the conversions with tests

## Verification
- go test ./...