### PR TITLE
Add catalog name lookup helpers

### DIFF
--- a/catalog/doc.go
+++ b/catalog/doc.go
@@ -1,8 +1,8 @@
 // Package catalog assembles the full Animal Crossing character dataset into
 // backend-friendly read-only registries without changing the underlying domain
-// model packages. It also provides exact-match, animal-scoped lookup helpers
-// over those registries, plus small DTO conversion helpers for transport-facing
-// callers.
+// model packages. It also provides exact-match lookup helpers over those
+// registries, small DTO conversion helpers for transport-facing callers, and a
+// narrow normalization layer for deterministic name lookups.
 //
 // The catalog remains grouped by animal because character keys are not
 // guaranteed to be globally unique across the full dataset.

--- a/catalog/name.go
+++ b/catalog/name.go
@@ -1,0 +1,79 @@
+package catalog
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/lindsaygelle/nook"
+	"golang.org/x/text/language"
+)
+
+// NormalizeLookupValue trims surrounding whitespace and folds case for exact
+// lookup operations. It does not remove accents or perform fuzzy matching.
+func NormalizeLookupValue(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+// ResidentsByName returns all residents whose localized name matches the
+// provided value after normalization. Results are sorted by animal key and then
+// character key for deterministic backend responses.
+func ResidentsByName(tag language.Tag, name string) []nook.Resident {
+	query := NormalizeLookupValue(name)
+	if query == "" {
+		return nil
+	}
+
+	residents := make([]nook.Resident, 0)
+	for _, bucket := range AllResidents {
+		for _, resident := range bucket {
+			localizedName, ok := resident.Name.Get(tag)
+			if !ok {
+				continue
+			}
+			if NormalizeLookupValue(localizedName.Value) != query {
+				continue
+			}
+			residents = append(residents, resident)
+		}
+	}
+
+	slices.SortFunc(residents, func(a, b nook.Resident) int {
+		if a.Animal.Key != b.Animal.Key {
+			return strings.Compare(string(a.Animal.Key), string(b.Animal.Key))
+		}
+		return strings.Compare(string(a.Key), string(b.Key))
+	})
+	return residents
+}
+
+// VillagersByName returns all villagers whose localized name matches the
+// provided value after normalization. Results are sorted by animal key and then
+// character key for deterministic backend responses.
+func VillagersByName(tag language.Tag, name string) []nook.Villager {
+	query := NormalizeLookupValue(name)
+	if query == "" {
+		return nil
+	}
+
+	villagers := make([]nook.Villager, 0)
+	for _, bucket := range AllVillagers {
+		for _, villager := range bucket {
+			localizedName, ok := villager.Name.Get(tag)
+			if !ok {
+				continue
+			}
+			if NormalizeLookupValue(localizedName.Value) != query {
+				continue
+			}
+			villagers = append(villagers, villager)
+		}
+	}
+
+	slices.SortFunc(villagers, func(a, b nook.Villager) int {
+		if a.Animal.Key != b.Animal.Key {
+			return strings.Compare(string(a.Animal.Key), string(b.Animal.Key))
+		}
+		return strings.Compare(string(a.Key), string(b.Key))
+	})
+	return villagers
+}

--- a/catalog/name_test.go
+++ b/catalog/name_test.go
@@ -1,0 +1,66 @@
+package catalog_test
+
+import (
+	"testing"
+
+	"github.com/lindsaygelle/nook/catalog"
+	"github.com/lindsaygelle/nook/character"
+	"golang.org/x/text/language"
+)
+
+func TestNormalizeLookupValue(t *testing.T) {
+	got := catalog.NormalizeLookupValue("  ToM NoOk  ")
+	if got != "tom nook" {
+		t.Fatalf("catalog.NormalizeLookupValue(...) = %q", got)
+	}
+}
+
+func TestVillagersByNameFindsDuplicateNamesDeterministically(t *testing.T) {
+	villagers := catalog.VillagersByName(language.AmericanEnglish, "  carmen ")
+	if len(villagers) != 2 {
+		t.Fatalf("len(catalog.VillagersByName(en-US, carmen)) = %d", len(villagers))
+	}
+	if villagers[0].Animal.Key != "Mouse" || villagers[0].Key != character.Carmen {
+		t.Fatalf("catalog.VillagersByName(en-US, carmen)[0] = %s/%s", villagers[0].Animal.Key, villagers[0].Key)
+	}
+	if villagers[1].Animal.Key != "Rabbit" || villagers[1].Key != character.Carmen {
+		t.Fatalf("catalog.VillagersByName(en-US, carmen)[1] = %s/%s", villagers[1].Animal.Key, villagers[1].Key)
+	}
+}
+
+func TestVillagersByNameMatchesLocaleExactlyAfterNormalization(t *testing.T) {
+	villagers := catalog.VillagersByName(language.French, " zoé ")
+	if len(villagers) != 2 {
+		t.Fatalf("len(catalog.VillagersByName(fr, zoé)) = %d", len(villagers))
+	}
+	if villagers[0].Animal.Key != "Anteater" || villagers[0].Key != character.Zoe {
+		t.Fatalf("catalog.VillagersByName(fr, zoé)[0] = %s/%s", villagers[0].Animal.Key, villagers[0].Key)
+	}
+	if villagers[1].Animal.Key != "Rabbit" || villagers[1].Key != character.Carmen {
+		t.Fatalf("catalog.VillagersByName(fr, zoé)[1] = %s/%s", villagers[1].Animal.Key, villagers[1].Key)
+	}
+
+	villagers = catalog.VillagersByName(language.French, "zoe")
+	if len(villagers) != 0 {
+		t.Fatalf("len(catalog.VillagersByName(fr, zoe)) = %d", len(villagers))
+	}
+}
+
+func TestResidentsByName(t *testing.T) {
+	residents := catalog.ResidentsByName(language.AmericanEnglish, " tom nook ")
+	if len(residents) != 1 {
+		t.Fatalf("len(catalog.ResidentsByName(en-US, tom nook)) = %d", len(residents))
+	}
+	if residents[0].Key != character.TomNook {
+		t.Fatalf("catalog.ResidentsByName(en-US, tom nook)[0].Key = %s", residents[0].Key)
+	}
+}
+
+func TestNameLookupBlankQuery(t *testing.T) {
+	if residents := catalog.ResidentsByName(language.AmericanEnglish, "   "); len(residents) != 0 {
+		t.Fatalf("len(catalog.ResidentsByName(en-US, blank)) = %d", len(residents))
+	}
+	if villagers := catalog.VillagersByName(language.AmericanEnglish, ""); len(villagers) != 0 {
+		t.Fatalf("len(catalog.VillagersByName(en-US, blank)) = %d", len(villagers))
+	}
+}


### PR DESCRIPTION
## Summary
- add deterministic name lookup helpers for villagers and residents in the catalog package
- add a small normalization helper for exact name matching without fuzzy behavior
- sort duplicate-name results consistently and cover locale-specific duplicates with tests

## Verification
- go test ./...