### PR TITLE
Add game-based catalog query helpers

### DIFF
--- a/catalog/game.go
+++ b/catalog/game.go
@@ -22,6 +22,19 @@ var gameReleaseOrder = map[nook.Key]int{
 	game.WildWorld.Key:           5,
 }
 
+func characterAppearsInGame(character nook.Character, gameKey nook.Key) bool {
+	if gameKey == "" {
+		return false
+	}
+
+	for _, appearance := range character.Games {
+		if appearance.Key == gameKey {
+			return true
+		}
+	}
+	return false
+}
+
 func compareGamesByReleaseOrder(a, b nook.Game) int {
 	left, ok := gameReleaseOrder[a.Key]
 	if !ok {
@@ -100,4 +113,48 @@ func LastAppearanceByID(id string) (nook.Game, bool) {
 		return nook.Game{}, false
 	}
 	return games[len(games)-1], true
+}
+
+// ResidentsByGame returns all residents that appear in the provided game.
+// Results are sorted by animal key and then character key for deterministic
+// backend responses.
+func ResidentsByGame(gameKey nook.Key) []nook.Resident {
+	if gameKey == "" {
+		return nil
+	}
+
+	residents := make([]nook.Resident, 0)
+	for _, bucket := range AllResidents {
+		for _, resident := range bucket {
+			if !characterAppearsInGame(resident.Character, gameKey) {
+				continue
+			}
+			residents = append(residents, resident)
+		}
+	}
+
+	slices.SortFunc(residents, compareResidents)
+	return residents
+}
+
+// VillagersByGame returns all villagers that appear in the provided game.
+// Results are sorted by animal key and then character key for deterministic
+// backend responses.
+func VillagersByGame(gameKey nook.Key) []nook.Villager {
+	if gameKey == "" {
+		return nil
+	}
+
+	villagers := make([]nook.Villager, 0)
+	for _, bucket := range AllVillagers {
+		for _, villager := range bucket {
+			if !characterAppearsInGame(villager.Character, gameKey) {
+				continue
+			}
+			villagers = append(villagers, villager)
+		}
+	}
+
+	slices.SortFunc(villagers, compareVillagers)
+	return villagers
 }

--- a/catalog/game_test.go
+++ b/catalog/game_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/animal"
 	"github.com/lindsaygelle/nook/catalog"
 	"github.com/lindsaygelle/nook/character"
 	catcharacters "github.com/lindsaygelle/nook/character/cat"
@@ -156,4 +157,89 @@ func TestCharacterGamesUsesComposedID(t *testing.T) {
 	if _, ok := catalog.CharacterGamesByID(string(character.Carmen)); ok {
 		t.Fatal("catalog.CharacterGamesByID(Carmen) unexpectedly found a character without animal scope")
 	}
+}
+
+func TestResidentsByGame(t *testing.T) {
+	residents := catalog.ResidentsByGame(game.NewLeaf.Key)
+	if len(residents) == 0 {
+		t.Fatal("catalog.ResidentsByGame(NewLeaf) returned no residents")
+	}
+
+	foundIsabelle := false
+	for i, resident := range residents {
+		if !appearsInGame(resident.Character.Games, game.NewLeaf.Key) {
+			t.Fatalf("catalog.ResidentsByGame(NewLeaf)[%d] missing NewLeaf appearance", i)
+		}
+		if resident.Character.Animal.Key == animal.Dog.Key && resident.Character.Key == character.Isabelle {
+			foundIsabelle = true
+		}
+		if i == 0 {
+			continue
+		}
+
+		prev := residents[i-1]
+		if resident.Character.Animal.Key < prev.Character.Animal.Key {
+			t.Fatalf("catalog.ResidentsByGame(NewLeaf)[%d] not sorted by animal key", i)
+		}
+		if resident.Character.Animal.Key == prev.Character.Animal.Key && resident.Character.Key < prev.Character.Key {
+			t.Fatalf("catalog.ResidentsByGame(NewLeaf)[%d] not sorted by character key", i)
+		}
+	}
+	if !foundIsabelle {
+		t.Fatal("catalog.ResidentsByGame(NewLeaf) missing Isabelle")
+	}
+}
+
+func TestResidentsByGameEmptyKey(t *testing.T) {
+	residents := catalog.ResidentsByGame("")
+	if residents != nil {
+		t.Fatalf("catalog.ResidentsByGame(\"\") = %#v", residents)
+	}
+}
+
+func TestVillagersByGame(t *testing.T) {
+	villagers := catalog.VillagersByGame(game.DoubutsuNoMoriPlus.Key)
+	if len(villagers) == 0 {
+		t.Fatal("catalog.VillagersByGame(DoubutsuNoMoriPlus) returned no villagers")
+	}
+
+	foundAnkha := false
+	for i, villager := range villagers {
+		if !appearsInGame(villager.Character.Games, game.DoubutsuNoMoriPlus.Key) {
+			t.Fatalf("catalog.VillagersByGame(DoubutsuNoMoriPlus)[%d] missing DoubutsuNoMoriPlus appearance", i)
+		}
+		if villager.Character.Animal.Key == animal.Cat.Key && villager.Character.Key == character.Ankha {
+			foundAnkha = true
+		}
+		if i == 0 {
+			continue
+		}
+
+		prev := villagers[i-1]
+		if villager.Character.Animal.Key < prev.Character.Animal.Key {
+			t.Fatalf("catalog.VillagersByGame(DoubutsuNoMoriPlus)[%d] not sorted by animal key", i)
+		}
+		if villager.Character.Animal.Key == prev.Character.Animal.Key && villager.Character.Key < prev.Character.Key {
+			t.Fatalf("catalog.VillagersByGame(DoubutsuNoMoriPlus)[%d] not sorted by character key", i)
+		}
+	}
+	if !foundAnkha {
+		t.Fatal("catalog.VillagersByGame(DoubutsuNoMoriPlus) missing Ankha")
+	}
+}
+
+func TestVillagersByGameEmptyKey(t *testing.T) {
+	villagers := catalog.VillagersByGame("")
+	if villagers != nil {
+		t.Fatalf("catalog.VillagersByGame(\"\") = %#v", villagers)
+	}
+}
+
+func appearsInGame(games []nook.Game, gameKey nook.Key) bool {
+	for _, appearance := range games {
+		if appearance.Key == gameKey {
+			return true
+		}
+	}
+	return false
 }

--- a/catalog/record.go
+++ b/catalog/record.go
@@ -140,6 +140,17 @@ func ResidentRecordsByBirthMonth(month time.Month) []ResidentRecord {
 	return records
 }
 
+// ResidentRecordsByGame returns all residents that appear in the provided
+// game. Results are ordered by animal key and then character key.
+func ResidentRecordsByGame(gameKey nook.Key) []ResidentRecord {
+	residents := ResidentsByGame(gameKey)
+	records := make([]ResidentRecord, 0, len(residents))
+	for _, resident := range residents {
+		records = append(records, ResidentRecordOf(resident))
+	}
+	return records
+}
+
 // VillagerRecordOf converts a domain villager into its API-facing record.
 func VillagerRecordOf(villager nook.Villager) VillagerRecord {
 	return VillagerRecord{
@@ -198,11 +209,11 @@ func VillagerRecordsByBirthday(month time.Month, day uint8) []VillagerRecord {
 	return records
 }
 
-// VillagerRecordsByPersonality returns all villagers whose localized
-// personality name matches the provided value after normalization. Results are
-// ordered by animal key and then character key.
-func VillagerRecordsByPersonality(tag language.Tag, personality string) []VillagerRecord {
-	villagers := VillagersByPersonality(tag, personality)
+// VillagerRecordsByBirthMonth returns all villagers whose birthday month
+// exactly matches the provided month. Results are ordered by animal key and
+// then character key.
+func VillagerRecordsByBirthMonth(month time.Month) []VillagerRecord {
+	villagers := VillagersByBirthMonth(month)
 	records := make([]VillagerRecord, 0, len(villagers))
 	for _, villager := range villagers {
 		records = append(records, VillagerRecordOf(villager))
@@ -210,11 +221,22 @@ func VillagerRecordsByPersonality(tag language.Tag, personality string) []Villag
 	return records
 }
 
-// VillagerRecordsByBirthMonth returns all villagers whose birthday month
-// exactly matches the provided month. Results are ordered by animal key and
-// then character key.
-func VillagerRecordsByBirthMonth(month time.Month) []VillagerRecord {
-	villagers := VillagersByBirthMonth(month)
+// VillagerRecordsByGame returns all villagers that appear in the provided
+// game. Results are ordered by animal key and then character key.
+func VillagerRecordsByGame(gameKey nook.Key) []VillagerRecord {
+	villagers := VillagersByGame(gameKey)
+	records := make([]VillagerRecord, 0, len(villagers))
+	for _, villager := range villagers {
+		records = append(records, VillagerRecordOf(villager))
+	}
+	return records
+}
+
+// VillagerRecordsByPersonality returns all villagers whose localized
+// personality name matches the provided value after normalization. Results are
+// ordered by animal key and then character key.
+func VillagerRecordsByPersonality(tag language.Tag, personality string) []VillagerRecord {
+	villagers := VillagersByPersonality(tag, personality)
 	records := make([]VillagerRecord, 0, len(villagers))
 	for _, villager := range villagers {
 		records = append(records, VillagerRecordOf(villager))

--- a/catalog/record_test.go
+++ b/catalog/record_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lindsaygelle/nook/character/dog"
 	"github.com/lindsaygelle/nook/character/mouse"
 	"github.com/lindsaygelle/nook/character/raccoon"
+	"github.com/lindsaygelle/nook/game"
 	"golang.org/x/text/language"
 )
 
@@ -136,6 +137,34 @@ func TestResidentRecordsByBirthMonth(t *testing.T) {
 	}
 }
 
+func TestResidentRecordsByGame(t *testing.T) {
+	records := catalog.ResidentRecordsByGame(game.NewLeaf.Key)
+	if len(records) == 0 {
+		t.Fatal("catalog.ResidentRecordsByGame(NewLeaf) returned no records")
+	}
+
+	foundTomNook := false
+	for i, record := range records {
+		if record.ID == "Raccoon:TomNook" {
+			foundTomNook = true
+		}
+		if i == 0 {
+			continue
+		}
+
+		prev := records[i-1]
+		if record.AnimalKey < prev.AnimalKey {
+			t.Fatalf("catalog.ResidentRecordsByGame(NewLeaf)[%d] not sorted by animal key", i)
+		}
+		if record.AnimalKey == prev.AnimalKey && record.Key < prev.Key {
+			t.Fatalf("catalog.ResidentRecordsByGame(NewLeaf)[%d] not sorted by character key", i)
+		}
+	}
+	if !foundTomNook {
+		t.Fatal("catalog.ResidentRecordsByGame(NewLeaf) missing Tom Nook")
+	}
+}
+
 func TestLocalizedValuesOfOmitsEmptyValues(t *testing.T) {
 	values := catalog.LocalizedValuesOf(mouse.Carmen.Name)
 
@@ -237,6 +266,34 @@ func TestVillagerRecordsByBirthMonth(t *testing.T) {
 	}
 }
 
+func TestVillagerRecordsByGame(t *testing.T) {
+	records := catalog.VillagerRecordsByGame(game.DoubutsuNoMoriPlus.Key)
+	if len(records) == 0 {
+		t.Fatal("catalog.VillagerRecordsByGame(DoubutsuNoMoriPlus) returned no records")
+	}
+
+	foundAnkha := false
+	for i, record := range records {
+		if record.ID == "Cat:Ankha" {
+			foundAnkha = true
+		}
+		if i == 0 {
+			continue
+		}
+
+		prev := records[i-1]
+		if record.AnimalKey < prev.AnimalKey {
+			t.Fatalf("catalog.VillagerRecordsByGame(DoubutsuNoMoriPlus)[%d] not sorted by animal key", i)
+		}
+		if record.AnimalKey == prev.AnimalKey && record.Key < prev.Key {
+			t.Fatalf("catalog.VillagerRecordsByGame(DoubutsuNoMoriPlus)[%d] not sorted by character key", i)
+		}
+	}
+	if !foundAnkha {
+		t.Fatal("catalog.VillagerRecordsByGame(DoubutsuNoMoriPlus) missing Ankha")
+	}
+}
+
 func TestRecordHelpersMissingAnimalBucket(t *testing.T) {
 	if _, ok := catalog.ResidentRecordsByAnimal("missing"); ok {
 		t.Fatal("catalog.ResidentRecordsByAnimal(missing) unexpectedly found a bucket")
@@ -265,8 +322,14 @@ func TestRecordHelpersMissingAnimalBucket(t *testing.T) {
 	if records := catalog.ResidentRecordsByBirthMonth(0); len(records) != 0 {
 		t.Fatalf("len(catalog.ResidentRecordsByBirthMonth(0)) = %d", len(records))
 	}
+	if records := catalog.ResidentRecordsByGame(""); len(records) != 0 {
+		t.Fatalf("len(catalog.ResidentRecordsByGame(\"\")) = %d", len(records))
+	}
 	if records := catalog.VillagerRecordsByBirthMonth(0); len(records) != 0 {
 		t.Fatalf("len(catalog.VillagerRecordsByBirthMonth(0)) = %d", len(records))
+	}
+	if records := catalog.VillagerRecordsByGame(""); len(records) != 0 {
+		t.Fatalf("len(catalog.VillagerRecordsByGame(\"\")) = %d", len(records))
 	}
 	if records := catalog.VillagerRecordsByPersonality(language.AmericanEnglish, ""); len(records) != 0 {
 		t.Fatalf("len(catalog.VillagerRecordsByPersonality(en-US, blank)) = %d", len(records))


### PR DESCRIPTION
### Description
Add inverse game-based catalog helpers so callers can query which residents and villagers appear in a specific Animal Crossing game.

### Related Issue
N/A

### Changes Made
- Added `catalog.ResidentsByGame` and `catalog.VillagersByGame` for deterministic game-centric queries.
- Added `catalog.ResidentRecordsByGame` and `catalog.VillagerRecordsByGame` for transport-friendly record output.
- Added catalog tests covering membership, deterministic sorting, and empty-key behavior for the new helpers.

### Screenshots (if applicable)
N/A

### How to Test
1. Run `go test ./...`.
2. Call `catalog.ResidentsByGame(game.NewLeaf.Key)` and confirm the results include residents such as Isabelle and are sorted deterministically.
3. Call `catalog.VillagersByGame(game.DoubutsuNoMoriPlus.Key)` and confirm the results include villagers such as Ankha and are sorted deterministically.
4. Call `catalog.ResidentRecordsByGame(...)` and `catalog.VillagerRecordsByGame(...)` and confirm the returned record slices match the same membership and order.

### Checklist
- [x] I have followed the coding style guidelines of the project.
- [x] My code passes all existing unit tests.
- [x] I have added new unit tests to cover the changes where applicable.
- [ ] I have updated the documentation to reflect the changes.
- [x] My changes do not introduce any new warnings or errors.
- [x] I have tested my changes thoroughly.

### Additional Notes
This keeps the change additive and deterministic. It extends the existing catalog query surface without changing the underlying character model.
