### PR TITLE
Expose game appearances in catalog records

### DIFF
--- a/catalog/record.go
+++ b/catalog/record.go
@@ -17,14 +17,21 @@ type BirthdayRecord struct {
 	Month uint8 `json:"month"`
 }
 
+// GameRecord is a transport-friendly game representation.
+type GameRecord struct {
+	Key  string          `json:"key"`
+	Name LocalizedValues `json:"name"`
+}
+
 // CharacterRecord is a flattened API-facing representation of a character.
 type CharacterRecord struct {
 	AnimalKey string          `json:"animal_key"`
 	Birthday  BirthdayRecord  `json:"birthday"`
 	Code      string          `json:"code,omitempty"`
-	ID        string          `json:"id"`
+	Games     []GameRecord    `json:"games"`
 	Gender    LocalizedValues `json:"gender"`
 	GenderKey string          `json:"gender_key"`
+	ID        string          `json:"id"`
 	Key       string          `json:"key"`
 	Name      LocalizedValues `json:"name"`
 	Special   bool            `json:"special"`
@@ -56,8 +63,26 @@ func LocalizedValuesOf(values nook.Languages) LocalizedValues {
 	return out
 }
 
+// GameRecordOf converts a domain game into its API-facing record.
+func GameRecordOf(game nook.Game) GameRecord {
+	return GameRecord{
+		Key:  string(game.Key),
+		Name: LocalizedValuesOf(game.Name),
+	}
+}
+
+func gameRecordsOf(games []nook.Game) []GameRecord {
+	records := make([]GameRecord, 0, len(games))
+	for _, game := range games {
+		records = append(records, GameRecordOf(game))
+	}
+	return records
+}
+
 // CharacterRecordOf converts a domain character into its API-facing record.
 func CharacterRecordOf(character nook.Character) CharacterRecord {
+	games := gameRecordsOf(sortedCharacterGames(character.Games))
+
 	return CharacterRecord{
 		AnimalKey: string(character.Animal.Key),
 		Birthday: BirthdayRecord{
@@ -65,9 +90,10 @@ func CharacterRecordOf(character nook.Character) CharacterRecord {
 			Month: uint8(character.Birthday.Month),
 		},
 		Code:      character.Code.Value,
-		ID:        string(character.ID()),
+		Games:     games,
 		Gender:    LocalizedValuesOf(character.Gender.Name),
 		GenderKey: string(character.Gender.Key),
+		ID:        string(character.ID()),
 		Key:       string(character.Key),
 		Name:      LocalizedValuesOf(character.Name),
 		Special:   character.Special,

--- a/catalog/record_test.go
+++ b/catalog/record_test.go
@@ -15,6 +15,17 @@ import (
 	"golang.org/x/text/language"
 )
 
+func TestGameRecordOf(t *testing.T) {
+	record := catalog.GameRecordOf(game.NewLeaf)
+
+	if record.Key != string(game.NewLeaf.Key) {
+		t.Fatalf("catalog.GameRecordOf(game.NewLeaf).Key = %s", record.Key)
+	}
+	if record.Name[language.AmericanEnglish.String()] != "Animal Crossing: New Leaf" {
+		t.Fatalf("catalog.GameRecordOf(game.NewLeaf).Name[en-US] = %s", record.Name[language.AmericanEnglish.String()])
+	}
+}
+
 func TestCharacterRecordOf(t *testing.T) {
 	record := catalog.CharacterRecordOf(cat.Ankha.Character)
 
@@ -36,6 +47,15 @@ func TestCharacterRecordOf(t *testing.T) {
 	if record.Name[language.AmericanEnglish.String()] != "Ankha" {
 		t.Fatalf("catalog.CharacterRecordOf(cat.Ankha).Name[en-US] = %s", record.Name[language.AmericanEnglish.String()])
 	}
+	if len(record.Games) != 9 {
+		t.Fatalf("len(catalog.CharacterRecordOf(cat.Ankha).Games) = %d", len(record.Games))
+	}
+	if record.Games[0].Key != string(game.DoubutsuNoMoriPlus.Key) {
+		t.Fatalf("catalog.CharacterRecordOf(cat.Ankha).Games[0].Key = %s", record.Games[0].Key)
+	}
+	if record.Games[len(record.Games)-1].Key != string(game.PocketCamp.Key) {
+		t.Fatalf("catalog.CharacterRecordOf(cat.Ankha).Games[last].Key = %s", record.Games[len(record.Games)-1].Key)
+	}
 }
 
 func TestVillagerRecordOf(t *testing.T) {
@@ -53,6 +73,9 @@ func TestVillagerRecordOf(t *testing.T) {
 	if record.Phrase[language.AmericanEnglish.String()] != "me meow" {
 		t.Fatalf("catalog.VillagerRecordOf(cat.Ankha).Phrase[en-US] = %s", record.Phrase[language.AmericanEnglish.String()])
 	}
+	if len(record.Games) != 9 {
+		t.Fatalf("len(catalog.VillagerRecordOf(cat.Ankha).Games) = %d", len(record.Games))
+	}
 }
 
 func TestResidentRecordOf(t *testing.T) {
@@ -66,6 +89,9 @@ func TestResidentRecordOf(t *testing.T) {
 	}
 	if record.Code != "rcn/rco" {
 		t.Fatalf("catalog.ResidentRecordOf(raccoon.TomNook).Code = %s", record.Code)
+	}
+	if len(record.Games) == 0 {
+		t.Fatal("catalog.ResidentRecordOf(raccoon.TomNook).Games returned no games")
 	}
 }
 


### PR DESCRIPTION
### Description
Add game appearance data to the transport-facing record layer so record consumers receive each character’s canonical game history directly in the record payload.

### Related Issue
N/A

### Changes Made
- Added `catalog.GameRecord` as a transport-friendly representation of a game.
- Added `catalog.GameRecordOf` for converting domain game values into transport records.
- Added `Games []GameRecord` to `catalog.CharacterRecord`.
- Updated `catalog.CharacterRecordOf` to populate `Games` in canonical release order using the existing character game data.
- Added record tests covering game conversion and game-list population for character, villager, and resident records.

### Screenshots (if applicable)
N/A

### How to Test
1. Run `go test ./...`.
2. Call `catalog.CharacterRecordOf(cat.Ankha.Character)` and confirm `Games` is populated in release order from `DoubutsuNoMoriPlus` through `PocketCamp`.
3. Call `catalog.GameRecordOf(game.NewLeaf)` and confirm the record contains the expected key and localized name.
4. Call `catalog.ResidentRecordOf(...)` and `catalog.VillagerRecordOf(...)` and confirm the embedded `CharacterRecord.Games` field is populated.

### Checklist
- [x] I have followed the coding style guidelines of the project.
- [x] My code passes all existing unit tests.
- [x] I have added new unit tests to cover the changes where applicable.
- [ ] I have updated the documentation to reflect the changes.
- [x] My changes do not introduce any new warnings or errors.
- [x] I have tested my changes thoroughly.

### Additional Notes
This is an additive record-surface change only. It does not change the underlying character model; it exposes existing game appearance data directly to record consumers.
