### PR TITLE
Add gender-based catalog query helpers

### DIFF
--- a/catalog/gender.go
+++ b/catalog/gender.go
@@ -1,0 +1,51 @@
+package catalog
+
+import (
+	"slices"
+
+	"github.com/lindsaygelle/nook"
+)
+
+// ResidentsByGender returns all residents whose gender exactly matches the
+// provided gender key. Results are sorted by animal key and then character key
+// for deterministic backend responses.
+func ResidentsByGender(genderKey nook.Key) []nook.Resident {
+	if genderKey == "" {
+		return nil
+	}
+
+	residents := make([]nook.Resident, 0)
+	for _, bucket := range AllResidents {
+		for _, resident := range bucket {
+			if resident.Character.Gender.Key != genderKey {
+				continue
+			}
+			residents = append(residents, resident)
+		}
+	}
+
+	slices.SortFunc(residents, compareResidents)
+	return residents
+}
+
+// VillagersByGender returns all villagers whose gender exactly matches the
+// provided gender key. Results are sorted by animal key and then character key
+// for deterministic backend responses.
+func VillagersByGender(genderKey nook.Key) []nook.Villager {
+	if genderKey == "" {
+		return nil
+	}
+
+	villagers := make([]nook.Villager, 0)
+	for _, bucket := range AllVillagers {
+		for _, villager := range bucket {
+			if villager.Character.Gender.Key != genderKey {
+				continue
+			}
+			villagers = append(villagers, villager)
+		}
+	}
+
+	slices.SortFunc(villagers, compareVillagers)
+	return villagers
+}

--- a/catalog/gender_test.go
+++ b/catalog/gender_test.go
@@ -1,0 +1,86 @@
+package catalog_test
+
+import (
+	"testing"
+
+	"github.com/lindsaygelle/nook/animal"
+	"github.com/lindsaygelle/nook/catalog"
+	"github.com/lindsaygelle/nook/character"
+	"github.com/lindsaygelle/nook/gender"
+)
+
+func TestResidentsByGender(t *testing.T) {
+	residents := catalog.ResidentsByGender(gender.Female.Key)
+	if len(residents) == 0 {
+		t.Fatal("catalog.ResidentsByGender(Female) returned no residents")
+	}
+
+	foundIsabelle := false
+	for i, resident := range residents {
+		if resident.Character.Gender.Key != gender.Female.Key {
+			t.Fatalf("catalog.ResidentsByGender(Female)[%d].Gender.Key = %s", i, resident.Character.Gender.Key)
+		}
+		if resident.Character.Animal.Key == animal.Dog.Key && resident.Character.Key == character.Isabelle {
+			foundIsabelle = true
+		}
+		if i == 0 {
+			continue
+		}
+
+		prev := residents[i-1]
+		if resident.Character.Animal.Key < prev.Character.Animal.Key {
+			t.Fatalf("catalog.ResidentsByGender(Female)[%d] not sorted by animal key", i)
+		}
+		if resident.Character.Animal.Key == prev.Character.Animal.Key && resident.Character.Key < prev.Character.Key {
+			t.Fatalf("catalog.ResidentsByGender(Female)[%d] not sorted by character key", i)
+		}
+	}
+	if !foundIsabelle {
+		t.Fatal("catalog.ResidentsByGender(Female) missing Isabelle")
+	}
+}
+
+func TestResidentsByGenderEmptyKey(t *testing.T) {
+	residents := catalog.ResidentsByGender("")
+	if residents != nil {
+		t.Fatalf("catalog.ResidentsByGender(\"\") = %#v", residents)
+	}
+}
+
+func TestVillagersByGender(t *testing.T) {
+	villagers := catalog.VillagersByGender(gender.Male.Key)
+	if len(villagers) == 0 {
+		t.Fatal("catalog.VillagersByGender(Male) returned no villagers")
+	}
+
+	foundAlfonso := false
+	for i, villager := range villagers {
+		if villager.Character.Gender.Key != gender.Male.Key {
+			t.Fatalf("catalog.VillagersByGender(Male)[%d].Gender.Key = %s", i, villager.Character.Gender.Key)
+		}
+		if villager.Character.Animal.Key == animal.Alligator.Key && villager.Character.Key == character.Alfonso {
+			foundAlfonso = true
+		}
+		if i == 0 {
+			continue
+		}
+
+		prev := villagers[i-1]
+		if villager.Character.Animal.Key < prev.Character.Animal.Key {
+			t.Fatalf("catalog.VillagersByGender(Male)[%d] not sorted by animal key", i)
+		}
+		if villager.Character.Animal.Key == prev.Character.Animal.Key && villager.Character.Key < prev.Character.Key {
+			t.Fatalf("catalog.VillagersByGender(Male)[%d] not sorted by character key", i)
+		}
+	}
+	if !foundAlfonso {
+		t.Fatal("catalog.VillagersByGender(Male) missing Alfonso")
+	}
+}
+
+func TestVillagersByGenderEmptyKey(t *testing.T) {
+	villagers := catalog.VillagersByGender("")
+	if villagers != nil {
+		t.Fatalf("catalog.VillagersByGender(\"\") = %#v", villagers)
+	}
+}

--- a/catalog/record.go
+++ b/catalog/record.go
@@ -177,6 +177,18 @@ func ResidentRecordsByGame(gameKey nook.Key) []ResidentRecord {
 	return records
 }
 
+// ResidentRecordsByGender returns all residents whose gender exactly matches
+// the provided gender key. Results are ordered by animal key and then
+// character key.
+func ResidentRecordsByGender(genderKey nook.Key) []ResidentRecord {
+	residents := ResidentsByGender(genderKey)
+	records := make([]ResidentRecord, 0, len(residents))
+	for _, resident := range residents {
+		records = append(records, ResidentRecordOf(resident))
+	}
+	return records
+}
+
 // VillagerRecordOf converts a domain villager into its API-facing record.
 func VillagerRecordOf(villager nook.Villager) VillagerRecord {
 	return VillagerRecord{
@@ -251,6 +263,18 @@ func VillagerRecordsByBirthMonth(month time.Month) []VillagerRecord {
 // game. Results are ordered by animal key and then character key.
 func VillagerRecordsByGame(gameKey nook.Key) []VillagerRecord {
 	villagers := VillagersByGame(gameKey)
+	records := make([]VillagerRecord, 0, len(villagers))
+	for _, villager := range villagers {
+		records = append(records, VillagerRecordOf(villager))
+	}
+	return records
+}
+
+// VillagerRecordsByGender returns all villagers whose gender exactly matches
+// the provided gender key. Results are ordered by animal key and then
+// character key.
+func VillagerRecordsByGender(genderKey nook.Key) []VillagerRecord {
+	villagers := VillagersByGender(genderKey)
 	records := make([]VillagerRecord, 0, len(villagers))
 	for _, villager := range villagers {
 		records = append(records, VillagerRecordOf(villager))

--- a/catalog/record_test.go
+++ b/catalog/record_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lindsaygelle/nook/character/mouse"
 	"github.com/lindsaygelle/nook/character/raccoon"
 	"github.com/lindsaygelle/nook/game"
+	"github.com/lindsaygelle/nook/gender"
 	"golang.org/x/text/language"
 )
 
@@ -191,6 +192,37 @@ func TestResidentRecordsByGame(t *testing.T) {
 	}
 }
 
+func TestResidentRecordsByGender(t *testing.T) {
+	records := catalog.ResidentRecordsByGender(gender.Female.Key)
+	if len(records) == 0 {
+		t.Fatal("catalog.ResidentRecordsByGender(Female) returned no records")
+	}
+
+	foundCeleste := false
+	for i, record := range records {
+		if record.GenderKey != string(gender.Female.Key) {
+			t.Fatalf("catalog.ResidentRecordsByGender(Female)[%d].GenderKey = %s", i, record.GenderKey)
+		}
+		if record.ID == "Owl:Celeste" {
+			foundCeleste = true
+		}
+		if i == 0 {
+			continue
+		}
+
+		prev := records[i-1]
+		if record.AnimalKey < prev.AnimalKey {
+			t.Fatalf("catalog.ResidentRecordsByGender(Female)[%d] not sorted by animal key", i)
+		}
+		if record.AnimalKey == prev.AnimalKey && record.Key < prev.Key {
+			t.Fatalf("catalog.ResidentRecordsByGender(Female)[%d] not sorted by character key", i)
+		}
+	}
+	if !foundCeleste {
+		t.Fatal("catalog.ResidentRecordsByGender(Female) missing Celeste")
+	}
+}
+
 func TestLocalizedValuesOfOmitsEmptyValues(t *testing.T) {
 	values := catalog.LocalizedValuesOf(mouse.Carmen.Name)
 
@@ -320,6 +352,37 @@ func TestVillagerRecordsByGame(t *testing.T) {
 	}
 }
 
+func TestVillagerRecordsByGender(t *testing.T) {
+	records := catalog.VillagerRecordsByGender(gender.Male.Key)
+	if len(records) == 0 {
+		t.Fatal("catalog.VillagerRecordsByGender(Male) returned no records")
+	}
+
+	foundMarshal := false
+	for i, record := range records {
+		if record.GenderKey != string(gender.Male.Key) {
+			t.Fatalf("catalog.VillagerRecordsByGender(Male)[%d].GenderKey = %s", i, record.GenderKey)
+		}
+		if record.ID == "Squirrel:Marshal" {
+			foundMarshal = true
+		}
+		if i == 0 {
+			continue
+		}
+
+		prev := records[i-1]
+		if record.AnimalKey < prev.AnimalKey {
+			t.Fatalf("catalog.VillagerRecordsByGender(Male)[%d] not sorted by animal key", i)
+		}
+		if record.AnimalKey == prev.AnimalKey && record.Key < prev.Key {
+			t.Fatalf("catalog.VillagerRecordsByGender(Male)[%d] not sorted by character key", i)
+		}
+	}
+	if !foundMarshal {
+		t.Fatal("catalog.VillagerRecordsByGender(Male) missing Marshal")
+	}
+}
+
 func TestRecordHelpersMissingAnimalBucket(t *testing.T) {
 	if _, ok := catalog.ResidentRecordsByAnimal("missing"); ok {
 		t.Fatal("catalog.ResidentRecordsByAnimal(missing) unexpectedly found a bucket")
@@ -351,11 +414,17 @@ func TestRecordHelpersMissingAnimalBucket(t *testing.T) {
 	if records := catalog.ResidentRecordsByGame(""); len(records) != 0 {
 		t.Fatalf("len(catalog.ResidentRecordsByGame(\"\")) = %d", len(records))
 	}
+	if records := catalog.ResidentRecordsByGender(""); len(records) != 0 {
+		t.Fatalf("len(catalog.ResidentRecordsByGender(\"\")) = %d", len(records))
+	}
 	if records := catalog.VillagerRecordsByBirthMonth(0); len(records) != 0 {
 		t.Fatalf("len(catalog.VillagerRecordsByBirthMonth(0)) = %d", len(records))
 	}
 	if records := catalog.VillagerRecordsByGame(""); len(records) != 0 {
 		t.Fatalf("len(catalog.VillagerRecordsByGame(\"\")) = %d", len(records))
+	}
+	if records := catalog.VillagerRecordsByGender(""); len(records) != 0 {
+		t.Fatalf("len(catalog.VillagerRecordsByGender(\"\")) = %d", len(records))
 	}
 	if records := catalog.VillagerRecordsByPersonality(language.AmericanEnglish, ""); len(records) != 0 {
 		t.Fatalf("len(catalog.VillagerRecordsByPersonality(en-US, blank)) = %d", len(records))


### PR DESCRIPTION
### Description
Add inverse gender-based catalog helpers so downstream Go consumers can query residents and villagers by exact gender key without walking the entire data set themselves.

### Related Issue
N/A

### Changes Made
- Added `catalog.ResidentsByGender` and `catalog.VillagersByGender` for exact `gender.Key` lookups.
- Added `catalog.ResidentRecordsByGender` and `catalog.VillagerRecordsByGender` to expose the same query shape through the record layer.
- Added tests covering expected matches, deterministic ordering, and empty-key behavior for both the domain and record helpers.

### Screenshots (if applicable)
Not applicable.

### How to Test
1. Run `go test ./...`
2. Verify `catalog.ResidentsByGender(gender.Female.Key)` includes Isabelle and Celeste.
3. Verify `catalog.VillagersByGender(gender.Male.Key)` includes Alfonso and Marshal.
4. Verify blank gender keys return no results.

### Checklist
- [x] I have followed the coding style guidelines of the project.
- [x] My code passes all existing unit tests.
- [x] I have added new unit tests to cover the changes where applicable.
- [ ] I have updated the documentation to reflect the changes.
- [x] My changes do not introduce any new warnings or errors.
- [x] I have tested my changes thoroughly.

### Additional Notes
This keeps the repository additive and self-sufficient as Go code by exposing another exact-key inverse index over the existing character facts.
