### PR TITLE
Add personality-key catalog query helpers

### DIFF
--- a/catalog/lookup_test.go
+++ b/catalog/lookup_test.go
@@ -13,6 +13,7 @@ import (
 	mousecharacters "github.com/lindsaygelle/nook/character/mouse"
 	rabbitcharacters "github.com/lindsaygelle/nook/character/rabbit"
 	raccooncharacters "github.com/lindsaygelle/nook/character/raccoon"
+	"github.com/lindsaygelle/nook/personality"
 	"golang.org/x/text/language"
 )
 
@@ -201,6 +202,26 @@ func TestVillagersByPersonalityDeterministic(t *testing.T) {
 	}
 }
 
+func TestVillagersByPersonalityKeyDeterministic(t *testing.T) {
+	villagers := catalog.VillagersByPersonalityKey(personality.Snooty.Key)
+	if len(villagers) != 66 {
+		t.Fatalf("len(catalog.VillagersByPersonalityKey(Snooty)) = %d", len(villagers))
+	}
+	if villagers[0].Animal.Key != animal.Alligator.Key || villagers[0].Key != character.Alli {
+		t.Fatalf("catalog.VillagersByPersonalityKey(Snooty)[0] = %s/%s", villagers[0].Animal.Key, villagers[0].Key)
+	}
+	if villagers[len(villagers)-1].Animal.Key != animal.Wolf.Key || villagers[len(villagers)-1].Key != character.Whitney {
+		t.Fatalf("catalog.VillagersByPersonalityKey(Snooty)[last] = %s/%s", villagers[len(villagers)-1].Animal.Key, villagers[len(villagers)-1].Key)
+	}
+	for i := 1; i < len(villagers); i++ {
+		leftAnimal := string(villagers[i-1].Animal.Key)
+		rightAnimal := string(villagers[i].Animal.Key)
+		if leftAnimal > rightAnimal || (leftAnimal == rightAnimal && string(villagers[i-1].Key) > string(villagers[i].Key)) {
+			t.Fatalf("catalog.VillagersByPersonalityKey(Snooty) not sorted at %s/%s > %s/%s", villagers[i-1].Animal.Key, villagers[i-1].Key, villagers[i].Animal.Key, villagers[i].Key)
+		}
+	}
+}
+
 func TestVillagerListByAnimalSorted(t *testing.T) {
 	villagers, ok := catalog.VillagerListByAnimal(animal.Mouse.Key)
 	if !ok {
@@ -264,5 +285,8 @@ func TestMissingAnimalBucket(t *testing.T) {
 	}
 	if villagers := catalog.VillagersByPersonality(language.French, "snooty"); len(villagers) != 0 {
 		t.Fatalf("len(catalog.VillagersByPersonality(fr, snooty)) = %d", len(villagers))
+	}
+	if villagers := catalog.VillagersByPersonalityKey(""); len(villagers) != 0 {
+		t.Fatalf("len(catalog.VillagersByPersonalityKey(\"\")) = %d", len(villagers))
 	}
 }

--- a/catalog/personality.go
+++ b/catalog/personality.go
@@ -7,6 +7,28 @@ import (
 	"golang.org/x/text/language"
 )
 
+// VillagersByPersonalityKey returns all villagers whose personality exactly
+// matches the provided personality key. Results are sorted by animal key and
+// then character key for deterministic backend responses.
+func VillagersByPersonalityKey(personalityKey nook.Key) []nook.Villager {
+	if personalityKey == "" {
+		return nil
+	}
+
+	villagers := make([]nook.Villager, 0)
+	for _, bucket := range AllVillagers {
+		for _, villager := range bucket {
+			if villager.Personality.Key != personalityKey {
+				continue
+			}
+			villagers = append(villagers, villager)
+		}
+	}
+
+	slices.SortFunc(villagers, compareVillagers)
+	return villagers
+}
+
 // VillagersByPersonality returns all villagers whose localized personality name
 // matches the provided value after normalization. Results are sorted by animal
 // key and then character key for deterministic backend responses.

--- a/catalog/record.go
+++ b/catalog/record.go
@@ -293,3 +293,15 @@ func VillagerRecordsByPersonality(tag language.Tag, personality string) []Villag
 	}
 	return records
 }
+
+// VillagerRecordsByPersonalityKey returns all villagers whose personality
+// exactly matches the provided personality key. Results are ordered by animal
+// key and then character key.
+func VillagerRecordsByPersonalityKey(personalityKey nook.Key) []VillagerRecord {
+	villagers := VillagersByPersonalityKey(personalityKey)
+	records := make([]VillagerRecord, 0, len(villagers))
+	for _, villager := range villagers {
+		records = append(records, VillagerRecordOf(villager))
+	}
+	return records
+}

--- a/catalog/record_test.go
+++ b/catalog/record_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lindsaygelle/nook/character/raccoon"
 	"github.com/lindsaygelle/nook/game"
 	"github.com/lindsaygelle/nook/gender"
+	"github.com/lindsaygelle/nook/personality"
 	"golang.org/x/text/language"
 )
 
@@ -308,6 +309,22 @@ func TestVillagerRecordsByPersonality(t *testing.T) {
 	}
 }
 
+func TestVillagerRecordsByPersonalityKey(t *testing.T) {
+	records := catalog.VillagerRecordsByPersonalityKey(personality.Snooty.Key)
+	if len(records) != 66 {
+		t.Fatalf("len(catalog.VillagerRecordsByPersonalityKey(Snooty)) = %d", len(records))
+	}
+	if records[0].Key != string(character.Alli) {
+		t.Fatalf("catalog.VillagerRecordsByPersonalityKey(Snooty)[0].Key = %s", records[0].Key)
+	}
+	if records[len(records)-1].Key != string(character.Whitney) {
+		t.Fatalf("catalog.VillagerRecordsByPersonalityKey(Snooty)[last].Key = %s", records[len(records)-1].Key)
+	}
+	if records[0].PersonalityKey != string(personality.Snooty.Key) {
+		t.Fatalf("catalog.VillagerRecordsByPersonalityKey(Snooty)[0].PersonalityKey = %s", records[0].PersonalityKey)
+	}
+}
+
 func TestVillagerRecordsByBirthMonth(t *testing.T) {
 	records := catalog.VillagerRecordsByBirthMonth(time.September)
 	if len(records) != 32 {
@@ -431,5 +448,8 @@ func TestRecordHelpersMissingAnimalBucket(t *testing.T) {
 	}
 	if records := catalog.VillagerRecordsByPersonality(language.French, "snooty"); len(records) != 0 {
 		t.Fatalf("len(catalog.VillagerRecordsByPersonality(fr, snooty)) = %d", len(records))
+	}
+	if records := catalog.VillagerRecordsByPersonalityKey(""); len(records) != 0 {
+		t.Fatalf("len(catalog.VillagerRecordsByPersonalityKey(\"\")) = %d", len(records))
 	}
 }


### PR DESCRIPTION
### Description
Add exact personality-key inverse query helpers to the catalog so downstream Go code can query villagers by canonical `personality.Key` values instead of only localized personality names.

### Related Issue
N/A

### Changes Made
- Added `catalog.VillagersByPersonalityKey` for exact villager personality-key lookups.
- Added `catalog.VillagerRecordsByPersonalityKey` to expose the same inverse query through the record layer.
- Added tests covering deterministic ordering, expected Snooty matches, and empty-key behavior while keeping the existing localized-name helper unchanged.

### Screenshots (if applicable)
Not applicable.

### How to Test
1. Run `go test ./...`
2. Verify `catalog.VillagersByPersonalityKey(personality.Snooty.Key)` returns 66 villagers.
3. Verify the first and last Snooty villagers remain `Alligator/Alli` and `Wolf/Whitney`.
4. Verify `catalog.VillagerRecordsByPersonalityKey(personality.Snooty.Key)` returns records with `PersonalityKey == "Snooty"`.
5. Verify blank personality keys return no results.

### Checklist
- [x] I have followed the coding style guidelines of the project.
- [x] My code passes all existing unit tests.
- [x] I have added new unit tests to cover the changes where applicable.
- [ ] I have updated the documentation to reflect the changes.
- [x] My changes do not introduce any new warnings or errors.
- [x] I have tested my changes thoroughly.

### Additional Notes
This keeps the catalog additive and self-sufficient as Go code by exposing an exact-key personality query alongside the existing localized personality-name lookup.
