### PR TITLE
Add canonical domain registries

### DIFF
--- a/animal/registry.go
+++ b/animal/registry.go
@@ -1,0 +1,91 @@
+package animal
+
+import "github.com/lindsaygelle/nook"
+
+var (
+	animals = []nook.Animal{
+		Alligator,
+		Alpaca,
+		Anteater,
+		Axolotl,
+		Bear,
+		Bearcub,
+		Beaver,
+		Bird,
+		Boar,
+		Bull,
+		Camel,
+		Cat,
+		Chameleon,
+		Chicken,
+		Cow,
+		Deer,
+		Dodo,
+		Dog,
+		Duck,
+		Eagle,
+		Elephant,
+		Fox,
+		FrillneckedLizard,
+		Frog,
+		FurSeal,
+		Giraffe,
+		Goat,
+		Gorilla,
+		Gyroid,
+		Hamster,
+		Hedgehog,
+		Hippo,
+		Horse,
+		Kangaroo,
+		Koala,
+		Lion,
+		Mole,
+		Monkey,
+		Mouse,
+		Octopus,
+		Ostrich,
+		Otter,
+		Owl,
+		Panther,
+		Peacock,
+		Pelican,
+		Penguin,
+		Pig,
+		Pigeon,
+		Rabbit,
+		Raccoon,
+		Reindeer,
+		Rhinoceros,
+		Seagull,
+		Sheep,
+		Skunk,
+		Sloth,
+		Squirrel,
+		Tapir,
+		Tiger,
+		Tortoise,
+		Turkey,
+		Turtle,
+		Walrus,
+		Wolf,
+	}
+	animalsByKey = func() map[nook.Key]nook.Animal {
+		index := make(map[nook.Key]nook.Animal, len(animals))
+		for _, animal := range animals {
+			index[animal.Key] = animal
+		}
+		return index
+	}()
+)
+
+// ByKey returns the canonical animal with the provided key.
+func ByKey(key nook.Key) (nook.Animal, bool) {
+	animal, ok := animalsByKey[key]
+	return animal, ok
+}
+
+// List returns all canonical animals in deterministic key order.
+func List() []nook.Animal {
+	return append([]nook.Animal(nil), animals...)
+}

--- a/animal/registry.go
+++ b/animal/registry.go
@@ -3,6 +3,7 @@ package animal
 import "github.com/lindsaygelle/nook"
 
 var (
+	// animals contains the canonical animals in deterministic key order.
 	animals = []nook.Animal{
 		Alligator,
 		Alpaca,
@@ -70,6 +71,10 @@ var (
 		Walrus,
 		Wolf,
 	}
+)
+
+var (
+	// animalsByKey contains canonical animals indexed by key.
 	animalsByKey = func() map[nook.Key]nook.Animal {
 		index := make(map[nook.Key]nook.Animal, len(animals))
 		for _, animal := range animals {

--- a/animal/registry_test.go
+++ b/animal/registry_test.go
@@ -1,0 +1,46 @@
+package animal_test
+
+import (
+	"testing"
+
+	"github.com/lindsaygelle/nook/animal"
+)
+
+func TestByKey(t *testing.T) {
+	got, ok := animal.ByKey(animal.FrillneckedLizard.Key)
+	if !ok {
+		t.Fatalf("animal.ByKey(%s) not found", animal.FrillneckedLizard.Key)
+	}
+	if got.Key != animal.FrillneckedLizard.Key {
+		t.Fatalf("animal.ByKey(%s).Key = %s", animal.FrillneckedLizard.Key, got.Key)
+	}
+}
+
+func TestByKeyMissing(t *testing.T) {
+	if _, ok := animal.ByKey("missing"); ok {
+		t.Fatal("animal.ByKey(missing) unexpectedly found an animal")
+	}
+}
+
+func TestList(t *testing.T) {
+	animals := animal.List()
+	if len(animals) != 65 {
+		t.Fatalf("len(animal.List()) = %d", len(animals))
+	}
+	if animals[0].Key != animal.Alligator.Key {
+		t.Fatalf("animal.List()[0].Key = %s", animals[0].Key)
+	}
+	if animals[len(animals)-1].Key != animal.Wolf.Key {
+		t.Fatalf("animal.List()[last].Key = %s", animals[len(animals)-1].Key)
+	}
+}
+
+func TestListReturnsCopy(t *testing.T) {
+	animals := animal.List()
+	animals[0] = animal.Wolf
+
+	fresh := animal.List()
+	if fresh[0].Key != animal.Alligator.Key {
+		t.Fatalf("animal.List()[0].Key after mutation = %s", fresh[0].Key)
+	}
+}

--- a/catalog/game.go
+++ b/catalog/game.go
@@ -4,16 +4,7 @@ import (
 	"slices"
 
 	"github.com/lindsaygelle/nook"
-	"github.com/lindsaygelle/nook/game"
 )
-
-var gameReleaseOrder = func() map[nook.Key]int {
-	order := make(map[nook.Key]int, len(game.List()))
-	for i, game := range game.List() {
-		order[game.Key] = i
-	}
-	return order
-}()
 
 func characterAppearsInGame(character nook.Character, gameKey nook.Key) bool {
 	if gameKey == "" {
@@ -29,19 +20,17 @@ func characterAppearsInGame(character nook.Character, gameKey nook.Key) bool {
 }
 
 func compareGamesByReleaseOrder(a, b nook.Game) int {
-	left, ok := gameReleaseOrder[a.Key]
-	if !ok {
-		left = len(gameReleaseOrder)
-	}
-	right, ok := gameReleaseOrder[b.Key]
-	if !ok {
-		right = len(gameReleaseOrder)
+	switch {
+	case a.ReleaseOrder == 0 && b.ReleaseOrder != 0:
+		return 1
+	case a.ReleaseOrder != 0 && b.ReleaseOrder == 0:
+		return -1
+	case a.ReleaseOrder < b.ReleaseOrder:
+		return -1
+	case a.ReleaseOrder > b.ReleaseOrder:
+		return 1
 	}
 	switch {
-	case left < right:
-		return -1
-	case left > right:
-		return 1
 	case a.Key < b.Key:
 		return -1
 	case a.Key > b.Key:

--- a/catalog/game.go
+++ b/catalog/game.go
@@ -7,20 +7,13 @@ import (
 	"github.com/lindsaygelle/nook/game"
 )
 
-var gameReleaseOrder = map[nook.Key]int{
-	game.AmiiboFestival.Key:      10,
-	game.AnimalCrossing.Key:      2,
-	game.CityFolk.Key:            6,
-	game.DongwuSenlin.Key:        4,
-	game.DoubutsuNoMori.Key:      0,
-	game.DoubutsuNoMoriEPlus.Key: 3,
-	game.DoubutsuNoMoriPlus.Key:  1,
-	game.HappyHomeDesigner.Key:   9,
-	game.NewHorizons.Key:         8,
-	game.NewLeaf.Key:             7,
-	game.PocketCamp.Key:          11,
-	game.WildWorld.Key:           5,
-}
+var gameReleaseOrder = func() map[nook.Key]int {
+	order := make(map[nook.Key]int, len(game.List()))
+	for i, game := range game.List() {
+		order[game.Key] = i
+	}
+	return order
+}()
 
 func characterAppearsInGame(character nook.Character, gameKey nook.Key) bool {
 	if gameKey == "" {

--- a/catalog/game_test.go
+++ b/catalog/game_test.go
@@ -25,10 +25,10 @@ func TestCharacterGamesByID(t *testing.T) {
 		game.DoubutsuNoMoriEPlus.Key,
 		game.CityFolk.Key,
 		game.NewLeaf.Key,
-		game.NewHorizons.Key,
 		game.HappyHomeDesigner.Key,
 		game.AmiiboFestival.Key,
 		game.PocketCamp.Key,
+		game.NewHorizons.Key,
 	}
 
 	if len(games) != len(expected) {
@@ -75,7 +75,7 @@ func TestFirstAndLastAppearanceByID(t *testing.T) {
 	if !ok {
 		t.Fatal("catalog.LastAppearanceByID(dog:Isabelle) not found")
 	}
-	if last.Key != game.PocketCamp.Key {
+	if last.Key != game.NewHorizons.Key {
 		t.Fatalf("catalog.LastAppearanceByID(dog:Isabelle).Key = %s", last.Key)
 	}
 }
@@ -93,7 +93,7 @@ func TestFirstAndLastAppearanceByCharacter(t *testing.T) {
 	if !ok {
 		t.Fatal("catalog.LastAppearance(Isabelle) not found")
 	}
-	if last.Key != game.PocketCamp.Key {
+	if last.Key != game.NewHorizons.Key {
 		t.Fatalf("catalog.LastAppearance(Isabelle).Key = %s", last.Key)
 	}
 }

--- a/catalog/record_test.go
+++ b/catalog/record_test.go
@@ -55,7 +55,7 @@ func TestCharacterRecordOf(t *testing.T) {
 	if record.Games[0].Key != string(game.DoubutsuNoMoriPlus.Key) {
 		t.Fatalf("catalog.CharacterRecordOf(cat.Ankha).Games[0].Key = %s", record.Games[0].Key)
 	}
-	if record.Games[len(record.Games)-1].Key != string(game.PocketCamp.Key) {
+	if record.Games[len(record.Games)-1].Key != string(game.NewHorizons.Key) {
 		t.Fatalf("catalog.CharacterRecordOf(cat.Ankha).Games[last].Key = %s", record.Games[len(record.Games)-1].Key)
 	}
 }

--- a/game.go
+++ b/game.go
@@ -7,4 +7,7 @@ type Game struct {
 
 	// Name contains the localized names of the game.
 	Name Languages
+
+	// ReleaseOrder is the series chronology position of the game.
+	ReleaseOrder uint8
 }

--- a/game/amiibo_festival.go
+++ b/game/amiibo_festival.go
@@ -28,7 +28,8 @@ var (
 var (
 	// AmiiboFestival represents Animal Crossing: amiibo Festival.
 	AmiiboFestival = nook.Game{
-		Key:  nook.Key(amiiboFestival),
-		Name: amiiboFestivalName,
+		Key:          nook.Key(amiiboFestival),
+		Name:         amiiboFestivalName,
+		ReleaseOrder: 10,
 	}
 )

--- a/game/animal_crossing.go
+++ b/game/animal_crossing.go
@@ -28,7 +28,8 @@ var (
 var (
 	// AnimalCrossing represents Animal Crossing.
 	AnimalCrossing = nook.Game{
-		Key:  nook.Key(animalCrossing),
-		Name: animalCrossingName,
+		Key:          nook.Key(animalCrossing),
+		Name:         animalCrossingName,
+		ReleaseOrder: 3,
 	}
 )

--- a/game/city_folk.go
+++ b/game/city_folk.go
@@ -28,7 +28,8 @@ var (
 var (
 	// CityFolk represents Animal Crossing: City Folk.
 	CityFolk = nook.Game{
-		Key:  nook.Key(cityFolk),
-		Name: cityFolkName,
+		Key:          nook.Key(cityFolk),
+		Name:         cityFolkName,
+		ReleaseOrder: 7,
 	}
 )

--- a/game/dongwu_senlin.go
+++ b/game/dongwu_senlin.go
@@ -28,7 +28,8 @@ var (
 var (
 	// DongwuSenlin represents Dongwu Senlin.
 	DongwuSenlin = nook.Game{
-		Key:  nook.Key(dongwuSenlin),
-		Name: dongwuSenlinName,
+		Key:          nook.Key(dongwuSenlin),
+		Name:         dongwuSenlinName,
+		ReleaseOrder: 5,
 	}
 )

--- a/game/doubutsu_no_mori.go
+++ b/game/doubutsu_no_mori.go
@@ -28,7 +28,8 @@ var (
 var (
 	// DoubutsuNoMori represents Doubutsu no Mori.
 	DoubutsuNoMori = nook.Game{
-		Key:  nook.Key(doubutsuNoMori),
-		Name: doubutsuNoMoriName,
+		Key:          nook.Key(doubutsuNoMori),
+		Name:         doubutsuNoMoriName,
+		ReleaseOrder: 1,
 	}
 )

--- a/game/doubutsu_no_mori_e_plus.go
+++ b/game/doubutsu_no_mori_e_plus.go
@@ -28,7 +28,8 @@ var (
 var (
 	// DoubutsuNoMoriEPlus represents Doubutsu no Mori e+.
 	DoubutsuNoMoriEPlus = nook.Game{
-		Key:  nook.Key(doubutsuNoMoriEPlus),
-		Name: doubutsuNoMoriEPlusName,
+		Key:          nook.Key(doubutsuNoMoriEPlus),
+		Name:         doubutsuNoMoriEPlusName,
+		ReleaseOrder: 4,
 	}
 )

--- a/game/doubutsu_no_mori_plus.go
+++ b/game/doubutsu_no_mori_plus.go
@@ -28,7 +28,8 @@ var (
 var (
 	// DoubutsuNoMoriPlus represents Doubutsu no Mori+.
 	DoubutsuNoMoriPlus = nook.Game{
-		Key:  nook.Key(doubutsuNoMoriPlus),
-		Name: doubutsuNoMoriPlusName,
+		Key:          nook.Key(doubutsuNoMoriPlus),
+		Name:         doubutsuNoMoriPlusName,
+		ReleaseOrder: 2,
 	}
 )

--- a/game/happy_home_designer.go
+++ b/game/happy_home_designer.go
@@ -28,7 +28,8 @@ var (
 var (
 	// HappyHomeDesigner represents Animal Crossing: Happy Home Designer.
 	HappyHomeDesigner = nook.Game{
-		Key:  nook.Key(happyHomeDesigner),
-		Name: happyHomeDesignerName,
+		Key:          nook.Key(happyHomeDesigner),
+		Name:         happyHomeDesignerName,
+		ReleaseOrder: 9,
 	}
 )

--- a/game/new_horizons.go
+++ b/game/new_horizons.go
@@ -28,7 +28,8 @@ var (
 var (
 	// NewHorizons represents Animal Crossing: New Horizons.
 	NewHorizons = nook.Game{
-		Key:  nook.Key(newHorizons),
-		Name: newHorizonsName,
+		Key:          nook.Key(newHorizons),
+		Name:         newHorizonsName,
+		ReleaseOrder: 12,
 	}
 )

--- a/game/new_leaf.go
+++ b/game/new_leaf.go
@@ -28,7 +28,8 @@ var (
 var (
 	// NewLeaf represents Animal Crossing: New Leaf.
 	NewLeaf = nook.Game{
-		Key:  nook.Key(newLeaf),
-		Name: newLeafName,
+		Key:          nook.Key(newLeaf),
+		Name:         newLeafName,
+		ReleaseOrder: 8,
 	}
 )

--- a/game/pocket_camp.go
+++ b/game/pocket_camp.go
@@ -28,7 +28,8 @@ var (
 var (
 	// PocketCamp represents Animal Crossing: Pocket Camp.
 	PocketCamp = nook.Game{
-		Key:  nook.Key(pocketCamp),
-		Name: pocketCampName,
+		Key:          nook.Key(pocketCamp),
+		Name:         pocketCampName,
+		ReleaseOrder: 11,
 	}
 )

--- a/game/registry.go
+++ b/game/registry.go
@@ -3,6 +3,7 @@ package game
 import "github.com/lindsaygelle/nook"
 
 var (
+	// games contains the canonical games in deterministic series order.
 	games = []nook.Game{
 		DoubutsuNoMori,
 		DoubutsuNoMoriPlus,
@@ -17,6 +18,10 @@ var (
 		PocketCamp,
 		NewHorizons,
 	}
+)
+
+var (
+	// gamesByKey contains canonical games indexed by key.
 	gamesByKey = func() map[nook.Key]nook.Game {
 		index := make(map[nook.Key]nook.Game, len(games))
 		for _, game := range games {

--- a/game/registry.go
+++ b/game/registry.go
@@ -1,0 +1,38 @@
+package game
+
+import "github.com/lindsaygelle/nook"
+
+var (
+	games = []nook.Game{
+		DoubutsuNoMori,
+		DoubutsuNoMoriPlus,
+		AnimalCrossing,
+		DoubutsuNoMoriEPlus,
+		DongwuSenlin,
+		WildWorld,
+		CityFolk,
+		NewLeaf,
+		HappyHomeDesigner,
+		AmiiboFestival,
+		PocketCamp,
+		NewHorizons,
+	}
+	gamesByKey = func() map[nook.Key]nook.Game {
+		index := make(map[nook.Key]nook.Game, len(games))
+		for _, game := range games {
+			index[game.Key] = game
+		}
+		return index
+	}()
+)
+
+// ByKey returns the canonical game with the provided key.
+func ByKey(key nook.Key) (nook.Game, bool) {
+	game, ok := gamesByKey[key]
+	return game, ok
+}
+
+// List returns all canonical games in deterministic series order.
+func List() []nook.Game {
+	return append([]nook.Game(nil), games...)
+}

--- a/game/registry_test.go
+++ b/game/registry_test.go
@@ -1,0 +1,46 @@
+package game_test
+
+import (
+	"testing"
+
+	"github.com/lindsaygelle/nook/game"
+)
+
+func TestByKey(t *testing.T) {
+	got, ok := game.ByKey(game.NewHorizons.Key)
+	if !ok {
+		t.Fatalf("game.ByKey(%s) not found", game.NewHorizons.Key)
+	}
+	if got.Key != game.NewHorizons.Key {
+		t.Fatalf("game.ByKey(%s).Key = %s", game.NewHorizons.Key, got.Key)
+	}
+}
+
+func TestByKeyMissing(t *testing.T) {
+	if _, ok := game.ByKey("missing"); ok {
+		t.Fatal("game.ByKey(missing) unexpectedly found a game")
+	}
+}
+
+func TestList(t *testing.T) {
+	games := game.List()
+	if len(games) != 12 {
+		t.Fatalf("len(game.List()) = %d", len(games))
+	}
+	if games[0].Key != game.DoubutsuNoMori.Key {
+		t.Fatalf("game.List()[0].Key = %s", games[0].Key)
+	}
+	if games[len(games)-1].Key != game.NewHorizons.Key {
+		t.Fatalf("game.List()[last].Key = %s", games[len(games)-1].Key)
+	}
+}
+
+func TestListReturnsCopy(t *testing.T) {
+	games := game.List()
+	games[0] = game.NewHorizons
+
+	fresh := game.List()
+	if fresh[0].Key != game.DoubutsuNoMori.Key {
+		t.Fatalf("game.List()[0].Key after mutation = %s", fresh[0].Key)
+	}
+}

--- a/game/registry_test.go
+++ b/game/registry_test.go
@@ -14,6 +14,9 @@ func TestByKey(t *testing.T) {
 	if got.Key != game.NewHorizons.Key {
 		t.Fatalf("game.ByKey(%s).Key = %s", game.NewHorizons.Key, got.Key)
 	}
+	if got.ReleaseOrder != 12 {
+		t.Fatalf("game.ByKey(%s).ReleaseOrder = %d", game.NewHorizons.Key, got.ReleaseOrder)
+	}
 }
 
 func TestByKeyMissing(t *testing.T) {
@@ -30,8 +33,20 @@ func TestList(t *testing.T) {
 	if games[0].Key != game.DoubutsuNoMori.Key {
 		t.Fatalf("game.List()[0].Key = %s", games[0].Key)
 	}
+	if games[0].ReleaseOrder != 1 {
+		t.Fatalf("game.List()[0].ReleaseOrder = %d", games[0].ReleaseOrder)
+	}
 	if games[len(games)-1].Key != game.NewHorizons.Key {
 		t.Fatalf("game.List()[last].Key = %s", games[len(games)-1].Key)
+	}
+	if games[len(games)-1].ReleaseOrder != 12 {
+		t.Fatalf("game.List()[last].ReleaseOrder = %d", games[len(games)-1].ReleaseOrder)
+	}
+
+	for i := 1; i < len(games); i++ {
+		if games[i-1].ReleaseOrder >= games[i].ReleaseOrder {
+			t.Fatalf("game.List() release order not increasing at %s >= %s", games[i-1].Key, games[i].Key)
+		}
 	}
 }
 

--- a/game/wild_world.go
+++ b/game/wild_world.go
@@ -28,7 +28,8 @@ var (
 var (
 	// WildWorld represents Animal Crossing: Wild World.
 	WildWorld = nook.Game{
-		Key:  nook.Key(wildWorld),
-		Name: wildWorldName,
+		Key:          nook.Key(wildWorld),
+		Name:         wildWorldName,
+		ReleaseOrder: 6,
 	}
 )

--- a/gender/registry.go
+++ b/gender/registry.go
@@ -3,10 +3,15 @@ package gender
 import "github.com/lindsaygelle/nook"
 
 var (
+	// genders contains the canonical genders in deterministic key order.
 	genders = []nook.Gender{
 		Female,
 		Male,
 	}
+)
+
+var (
+	// gendersByKey contains canonical genders indexed by key.
 	gendersByKey = func() map[nook.Key]nook.Gender {
 		index := make(map[nook.Key]nook.Gender, len(genders))
 		for _, gender := range genders {

--- a/gender/registry.go
+++ b/gender/registry.go
@@ -1,0 +1,28 @@
+package gender
+
+import "github.com/lindsaygelle/nook"
+
+var (
+	genders = []nook.Gender{
+		Female,
+		Male,
+	}
+	gendersByKey = func() map[nook.Key]nook.Gender {
+		index := make(map[nook.Key]nook.Gender, len(genders))
+		for _, gender := range genders {
+			index[gender.Key] = gender
+		}
+		return index
+	}()
+)
+
+// ByKey returns the canonical gender with the provided key.
+func ByKey(key nook.Key) (nook.Gender, bool) {
+	gender, ok := gendersByKey[key]
+	return gender, ok
+}
+
+// List returns all canonical genders in deterministic key order.
+func List() []nook.Gender {
+	return append([]nook.Gender(nil), genders...)
+}

--- a/gender/registry_test.go
+++ b/gender/registry_test.go
@@ -1,0 +1,46 @@
+package gender_test
+
+import (
+	"testing"
+
+	"github.com/lindsaygelle/nook/gender"
+)
+
+func TestByKey(t *testing.T) {
+	got, ok := gender.ByKey(gender.Female.Key)
+	if !ok {
+		t.Fatalf("gender.ByKey(%s) not found", gender.Female.Key)
+	}
+	if got.Key != gender.Female.Key {
+		t.Fatalf("gender.ByKey(%s).Key = %s", gender.Female.Key, got.Key)
+	}
+}
+
+func TestByKeyMissing(t *testing.T) {
+	if _, ok := gender.ByKey("missing"); ok {
+		t.Fatal("gender.ByKey(missing) unexpectedly found a gender")
+	}
+}
+
+func TestList(t *testing.T) {
+	genders := gender.List()
+	if len(genders) != 2 {
+		t.Fatalf("len(gender.List()) = %d", len(genders))
+	}
+	if genders[0].Key != gender.Female.Key {
+		t.Fatalf("gender.List()[0].Key = %s", genders[0].Key)
+	}
+	if genders[1].Key != gender.Male.Key {
+		t.Fatalf("gender.List()[1].Key = %s", genders[1].Key)
+	}
+}
+
+func TestListReturnsCopy(t *testing.T) {
+	genders := gender.List()
+	genders[0] = gender.Male
+
+	fresh := gender.List()
+	if fresh[0].Key != gender.Female.Key {
+		t.Fatalf("gender.List()[0].Key after mutation = %s", fresh[0].Key)
+	}
+}

--- a/personality/registry.go
+++ b/personality/registry.go
@@ -1,0 +1,34 @@
+package personality
+
+import "github.com/lindsaygelle/nook"
+
+var (
+	personalities = []nook.Personality{
+		BigSister,
+		Cranky,
+		Jock,
+		Lazy,
+		Normal,
+		Peppy,
+		Smug,
+		Snooty,
+	}
+	personalitiesByKey = func() map[nook.Key]nook.Personality {
+		index := make(map[nook.Key]nook.Personality, len(personalities))
+		for _, personality := range personalities {
+			index[personality.Key] = personality
+		}
+		return index
+	}()
+)
+
+// ByKey returns the canonical personality with the provided key.
+func ByKey(key nook.Key) (nook.Personality, bool) {
+	personality, ok := personalitiesByKey[key]
+	return personality, ok
+}
+
+// List returns all canonical personalities in deterministic key order.
+func List() []nook.Personality {
+	return append([]nook.Personality(nil), personalities...)
+}

--- a/personality/registry.go
+++ b/personality/registry.go
@@ -3,6 +3,7 @@ package personality
 import "github.com/lindsaygelle/nook"
 
 var (
+	// personalities contains the canonical personalities in deterministic key order.
 	personalities = []nook.Personality{
 		BigSister,
 		Cranky,
@@ -13,6 +14,10 @@ var (
 		Smug,
 		Snooty,
 	}
+)
+
+var (
+	// personalitiesByKey contains canonical personalities indexed by key.
 	personalitiesByKey = func() map[nook.Key]nook.Personality {
 		index := make(map[nook.Key]nook.Personality, len(personalities))
 		for _, personality := range personalities {

--- a/personality/registry_test.go
+++ b/personality/registry_test.go
@@ -1,0 +1,46 @@
+package personality_test
+
+import (
+	"testing"
+
+	"github.com/lindsaygelle/nook/personality"
+)
+
+func TestByKey(t *testing.T) {
+	got, ok := personality.ByKey(personality.Snooty.Key)
+	if !ok {
+		t.Fatalf("personality.ByKey(%s) not found", personality.Snooty.Key)
+	}
+	if got.Key != personality.Snooty.Key {
+		t.Fatalf("personality.ByKey(%s).Key = %s", personality.Snooty.Key, got.Key)
+	}
+}
+
+func TestByKeyMissing(t *testing.T) {
+	if _, ok := personality.ByKey("missing"); ok {
+		t.Fatal("personality.ByKey(missing) unexpectedly found a personality")
+	}
+}
+
+func TestList(t *testing.T) {
+	personalities := personality.List()
+	if len(personalities) != 8 {
+		t.Fatalf("len(personality.List()) = %d", len(personalities))
+	}
+	if personalities[0].Key != personality.BigSister.Key {
+		t.Fatalf("personality.List()[0].Key = %s", personalities[0].Key)
+	}
+	if personalities[len(personalities)-1].Key != personality.Snooty.Key {
+		t.Fatalf("personality.List()[last].Key = %s", personalities[len(personalities)-1].Key)
+	}
+}
+
+func TestListReturnsCopy(t *testing.T) {
+	personalities := personality.List()
+	personalities[0] = personality.Snooty
+
+	fresh := personality.List()
+	if fresh[0].Key != personality.BigSister.Key {
+		t.Fatalf("personality.List()[0].Key after mutation = %s", fresh[0].Key)
+	}
+}


### PR DESCRIPTION
### Description
Add package-owned canonical registries for animals, games, genders, and personalities so downstream Go code can enumerate and resolve these core domain values without rebuilding its own indexes.

### Related Issue
N/A

### Changes Made
- Added `List` and `ByKey` helpers to the `animal`, `game`, `gender`, and `personality` packages, each backed by a single package-owned registry built from the canonical exported values.
- Added tests covering deterministic ordering, exact-key lookup behavior, missing-key behavior, and slice-copy safety for each new registry.
- Updated `catalog/game.go` to derive its chronology order from the canonical `game.List()` registry instead of maintaining a second hardcoded game-order map.
- Corrected the resulting chronology expectations in catalog tests so late-series appearances now end with `NewHorizons` when applicable.

### Screenshots (if applicable)
Not applicable.

### How to Test
1. Run `go test ./...`
2. Verify `animal.List()` returns all canonical animals in deterministic order and `animal.ByKey(animal.FrillneckedLizard.Key)` resolves correctly.
3. Verify `game.List()` returns the package game chronology and `game.ByKey(game.NewHorizons.Key)` resolves correctly.
4. Verify `catalog.CharacterGamesByID("cat:Ankha")` now ends with `NewHorizons`.
5. Verify `catalog.LastAppearanceByID("dog:Isabelle")` now returns `NewHorizons`.

### Checklist
- [x] I have followed the coding style guidelines of the project.
- [x] My code passes all existing unit tests.
- [x] I have added new unit tests to cover the changes where applicable.
- [ ] I have updated the documentation to reflect the changes.
- [x] My changes do not introduce any new warnings or errors.
- [x] I have tested my changes thoroughly.

### Additional Notes
This keeps data ownership in the domain packages themselves rather than moving more canonical facts into `catalog`, while still giving downstream consumers a straightforward way to enumerate and resolve the core registries.
