### PR TITLE
Add game-owned regional release dates

### DIFF
--- a/catalog/record.go
+++ b/catalog/record.go
@@ -17,10 +17,21 @@ type BirthdayRecord struct {
 	Month uint8 `json:"month"`
 }
 
+// ReleaseDateRecord is a transport-friendly game release date representation.
+type ReleaseDateRecord struct {
+	Day       uint8           `json:"day"`
+	Month     uint8           `json:"month"`
+	Region    LocalizedValues `json:"region"`
+	RegionKey string          `json:"region_key"`
+	Year      uint16          `json:"year"`
+}
+
 // GameRecord is a transport-friendly game representation.
 type GameRecord struct {
-	Key  string          `json:"key"`
-	Name LocalizedValues `json:"name"`
+	Key          string              `json:"key"`
+	Name         LocalizedValues     `json:"name"`
+	ReleaseDates []ReleaseDateRecord `json:"release_dates"`
+	ReleaseOrder uint8               `json:"release_order"`
 }
 
 // CharacterRecord is a flattened API-facing representation of a character.
@@ -50,6 +61,32 @@ type VillagerRecord struct {
 	Phrase         LocalizedValues `json:"phrase"`
 }
 
+func gameRecordsOf(games []nook.Game) []GameRecord {
+	records := make([]GameRecord, 0, len(games))
+	for _, game := range games {
+		records = append(records, GameRecordOf(game))
+	}
+	return records
+}
+
+func releaseDateRecordOf(releaseDate nook.ReleaseDate) ReleaseDateRecord {
+	return ReleaseDateRecord{
+		Day:       releaseDate.Day,
+		Month:     uint8(releaseDate.Month),
+		Region:    LocalizedValuesOf(releaseDate.Region.Name),
+		RegionKey: string(releaseDate.Region.Key),
+		Year:      releaseDate.Year,
+	}
+}
+
+func releaseDateRecordsOf(releaseDates []nook.ReleaseDate) []ReleaseDateRecord {
+	records := make([]ReleaseDateRecord, 0, len(releaseDates))
+	for _, releaseDate := range releaseDates {
+		records = append(records, releaseDateRecordOf(releaseDate))
+	}
+	return records
+}
+
 // LocalizedValuesOf converts language-tagged values into a transport-friendly
 // map and omits empty values.
 func LocalizedValuesOf(values nook.Languages) LocalizedValues {
@@ -66,17 +103,11 @@ func LocalizedValuesOf(values nook.Languages) LocalizedValues {
 // GameRecordOf converts a domain game into its API-facing record.
 func GameRecordOf(game nook.Game) GameRecord {
 	return GameRecord{
-		Key:  string(game.Key),
-		Name: LocalizedValuesOf(game.Name),
+		Key:          string(game.Key),
+		Name:         LocalizedValuesOf(game.Name),
+		ReleaseDates: releaseDateRecordsOf(game.ReleaseDates),
+		ReleaseOrder: game.ReleaseOrder,
 	}
-}
-
-func gameRecordsOf(games []nook.Game) []GameRecord {
-	records := make([]GameRecord, 0, len(games))
-	for _, game := range games {
-		records = append(records, GameRecordOf(game))
-	}
-	return records
 }
 
 // CharacterRecordOf converts a domain character into its API-facing record.

--- a/catalog/record_test.go
+++ b/catalog/record_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lindsaygelle/nook/game"
 	"github.com/lindsaygelle/nook/gender"
 	"github.com/lindsaygelle/nook/personality"
+	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
 
@@ -25,6 +26,21 @@ func TestGameRecordOf(t *testing.T) {
 	}
 	if record.Name[language.AmericanEnglish.String()] != "Animal Crossing: New Leaf" {
 		t.Fatalf("catalog.GameRecordOf(game.NewLeaf).Name[en-US] = %s", record.Name[language.AmericanEnglish.String()])
+	}
+	if record.ReleaseOrder != game.NewLeaf.ReleaseOrder {
+		t.Fatalf("catalog.GameRecordOf(game.NewLeaf).ReleaseOrder = %d", record.ReleaseOrder)
+	}
+	if len(record.ReleaseDates) != 4 {
+		t.Fatalf("len(catalog.GameRecordOf(game.NewLeaf).ReleaseDates) = %d", len(record.ReleaseDates))
+	}
+	if record.ReleaseDates[0].RegionKey != string(region.Japan.Key) {
+		t.Fatalf("catalog.GameRecordOf(game.NewLeaf).ReleaseDates[0].RegionKey = %s", record.ReleaseDates[0].RegionKey)
+	}
+	if record.ReleaseDates[0].Region[language.AmericanEnglish.String()] != "Japan" {
+		t.Fatalf("catalog.GameRecordOf(game.NewLeaf).ReleaseDates[0].Region[en-US] = %s", record.ReleaseDates[0].Region[language.AmericanEnglish.String()])
+	}
+	if record.ReleaseDates[0].Year != 2012 || record.ReleaseDates[0].Month != 11 || record.ReleaseDates[0].Day != 8 {
+		t.Fatalf("catalog.GameRecordOf(game.NewLeaf).ReleaseDates[0] = %#v", record.ReleaseDates[0])
 	}
 }
 

--- a/game.go
+++ b/game.go
@@ -8,6 +8,41 @@ type Game struct {
 	// Name contains the localized names of the game.
 	Name Languages
 
+	// ReleaseDates contains the game's known regional release history in
+	// chronological order.
+	ReleaseDates []ReleaseDate
+
 	// ReleaseOrder is the series chronology position of the game.
 	ReleaseOrder uint8
+}
+
+// FirstReleaseDate returns the earliest known release date for the game.
+func (g Game) FirstReleaseDate() (ReleaseDate, bool) {
+	if len(g.ReleaseDates) == 0 {
+		return ReleaseDate{}, false
+	}
+	return g.ReleaseDates[0], true
+}
+
+// LastReleaseDate returns the latest known release date for the game.
+func (g Game) LastReleaseDate() (ReleaseDate, bool) {
+	if len(g.ReleaseDates) == 0 {
+		return ReleaseDate{}, false
+	}
+	return g.ReleaseDates[len(g.ReleaseDates)-1], true
+}
+
+// ReleaseDateByRegion returns the game's release date for the provided region.
+func (g Game) ReleaseDateByRegion(regionKey Key) (ReleaseDate, bool) {
+	if regionKey == "" {
+		return ReleaseDate{}, false
+	}
+
+	for _, releaseDate := range g.ReleaseDates {
+		if releaseDate.Region.Key == regionKey {
+			return releaseDate, true
+		}
+	}
+
+	return ReleaseDate{}, false
 }

--- a/game/amiibo_festival.go
+++ b/game/amiibo_festival.go
@@ -1,7 +1,10 @@
 package game
 
 import (
+	"time"
+
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
 
@@ -19,9 +22,53 @@ var (
 )
 
 var (
+	// amiiboFestivalReleaseDateAustralia represents Animal Crossing: amiibo Festival's release date in Australia.
+	amiiboFestivalReleaseDateAustralia = nook.ReleaseDate{
+		Day:    21,
+		Month:  time.November,
+		Region: region.Australia,
+		Year:   2015,
+	}
+
+	// amiiboFestivalReleaseDateEurope represents Animal Crossing: amiibo Festival's release date in Europe.
+	amiiboFestivalReleaseDateEurope = nook.ReleaseDate{
+		Day:    21,
+		Month:  time.November,
+		Region: region.Europe,
+		Year:   2015,
+	}
+
+	// amiiboFestivalReleaseDateJapan represents Animal Crossing: amiibo Festival's release date in Japan.
+	amiiboFestivalReleaseDateJapan = nook.ReleaseDate{
+		Day:    13,
+		Month:  time.November,
+		Region: region.Japan,
+		Year:   2015,
+	}
+
+	// amiiboFestivalReleaseDateNorthAmerica represents Animal Crossing: amiibo Festival's release date in North America.
+	amiiboFestivalReleaseDateNorthAmerica = nook.ReleaseDate{
+		Day:    20,
+		Month:  time.November,
+		Region: region.NorthAmerica,
+		Year:   2015,
+	}
+)
+
+var (
 	// amiiboFestivalName contains the localized names of Animal Crossing: amiibo Festival.
 	amiiboFestivalName = nook.Languages{
 		language.AmericanEnglish: amiiboFestivalNameAmericanEnglish,
+	}
+)
+
+var (
+	// amiiboFestivalReleaseDates contains Animal Crossing: amiibo Festival's regional release history in chronological order.
+	amiiboFestivalReleaseDates = []nook.ReleaseDate{
+		amiiboFestivalReleaseDateJapan,
+		amiiboFestivalReleaseDateNorthAmerica,
+		amiiboFestivalReleaseDateAustralia,
+		amiiboFestivalReleaseDateEurope,
 	}
 )
 
@@ -30,6 +77,7 @@ var (
 	AmiiboFestival = nook.Game{
 		Key:          nook.Key(amiiboFestival),
 		Name:         amiiboFestivalName,
+		ReleaseDates: amiiboFestivalReleaseDates,
 		ReleaseOrder: 10,
 	}
 )

--- a/game/animal_crossing.go
+++ b/game/animal_crossing.go
@@ -1,7 +1,10 @@
 package game
 
 import (
+	"time"
+
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
 
@@ -19,9 +22,44 @@ var (
 )
 
 var (
+	// animalCrossingReleaseDateAustralia represents Animal Crossing's release date in Australia.
+	animalCrossingReleaseDateAustralia = nook.ReleaseDate{
+		Day:    17,
+		Month:  time.October,
+		Region: region.Australia,
+		Year:   2003,
+	}
+
+	// animalCrossingReleaseDateEurope represents Animal Crossing's release date in Europe.
+	animalCrossingReleaseDateEurope = nook.ReleaseDate{
+		Day:    24,
+		Month:  time.September,
+		Region: region.Europe,
+		Year:   2004,
+	}
+
+	// animalCrossingReleaseDateNorthAmerica represents Animal Crossing's release date in North America.
+	animalCrossingReleaseDateNorthAmerica = nook.ReleaseDate{
+		Day:    16,
+		Month:  time.September,
+		Region: region.NorthAmerica,
+		Year:   2002,
+	}
+)
+
+var (
 	// animalCrossingName contains the localized names of Animal Crossing.
 	animalCrossingName = nook.Languages{
 		language.AmericanEnglish: animalCrossingNameAmericanEnglish,
+	}
+)
+
+var (
+	// animalCrossingReleaseDates contains Animal Crossing's regional release history in chronological order.
+	animalCrossingReleaseDates = []nook.ReleaseDate{
+		animalCrossingReleaseDateNorthAmerica,
+		animalCrossingReleaseDateAustralia,
+		animalCrossingReleaseDateEurope,
 	}
 )
 
@@ -30,6 +68,7 @@ var (
 	AnimalCrossing = nook.Game{
 		Key:          nook.Key(animalCrossing),
 		Name:         animalCrossingName,
+		ReleaseDates: animalCrossingReleaseDates,
 		ReleaseOrder: 3,
 	}
 )

--- a/game/city_folk.go
+++ b/game/city_folk.go
@@ -1,7 +1,10 @@
 package game
 
 import (
+	"time"
+
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
 
@@ -19,9 +22,53 @@ var (
 )
 
 var (
+	// cityFolkReleaseDateAustralia represents Animal Crossing: City Folk's release date in Australia.
+	cityFolkReleaseDateAustralia = nook.ReleaseDate{
+		Day:    4,
+		Month:  time.December,
+		Region: region.Australia,
+		Year:   2008,
+	}
+
+	// cityFolkReleaseDateEurope represents Animal Crossing: City Folk's release date in Europe.
+	cityFolkReleaseDateEurope = nook.ReleaseDate{
+		Day:    5,
+		Month:  time.December,
+		Region: region.Europe,
+		Year:   2008,
+	}
+
+	// cityFolkReleaseDateJapan represents Animal Crossing: City Folk's release date in Japan.
+	cityFolkReleaseDateJapan = nook.ReleaseDate{
+		Day:    20,
+		Month:  time.November,
+		Region: region.Japan,
+		Year:   2008,
+	}
+
+	// cityFolkReleaseDateNorthAmerica represents Animal Crossing: City Folk's release date in North America.
+	cityFolkReleaseDateNorthAmerica = nook.ReleaseDate{
+		Day:    16,
+		Month:  time.November,
+		Region: region.NorthAmerica,
+		Year:   2008,
+	}
+)
+
+var (
 	// cityFolkName contains the localized names of Animal Crossing: City Folk.
 	cityFolkName = nook.Languages{
 		language.AmericanEnglish: cityFolkNameAmericanEnglish,
+	}
+)
+
+var (
+	// cityFolkReleaseDates contains Animal Crossing: City Folk's regional release history in chronological order.
+	cityFolkReleaseDates = []nook.ReleaseDate{
+		cityFolkReleaseDateNorthAmerica,
+		cityFolkReleaseDateJapan,
+		cityFolkReleaseDateAustralia,
+		cityFolkReleaseDateEurope,
 	}
 )
 
@@ -30,6 +77,7 @@ var (
 	CityFolk = nook.Game{
 		Key:          nook.Key(cityFolk),
 		Name:         cityFolkName,
+		ReleaseDates: cityFolkReleaseDates,
 		ReleaseOrder: 7,
 	}
 )

--- a/game/dongwu_senlin.go
+++ b/game/dongwu_senlin.go
@@ -1,7 +1,10 @@
 package game
 
 import (
+	"time"
+
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
 
@@ -19,9 +22,26 @@ var (
 )
 
 var (
+	// dongwuSenlinReleaseDateChina represents Dongwu Senlin's release date in China.
+	dongwuSenlinReleaseDateChina = nook.ReleaseDate{
+		Day:    1,
+		Month:  time.June,
+		Region: region.China,
+		Year:   2006,
+	}
+)
+
+var (
 	// dongwuSenlinName contains the localized names of Dongwu Senlin.
 	dongwuSenlinName = nook.Languages{
 		language.AmericanEnglish: dongwuSenlinNameAmericanEnglish,
+	}
+)
+
+var (
+	// dongwuSenlinReleaseDates contains Dongwu Senlin's regional release history in chronological order.
+	dongwuSenlinReleaseDates = []nook.ReleaseDate{
+		dongwuSenlinReleaseDateChina,
 	}
 )
 
@@ -30,6 +50,7 @@ var (
 	DongwuSenlin = nook.Game{
 		Key:          nook.Key(dongwuSenlin),
 		Name:         dongwuSenlinName,
+		ReleaseDates: dongwuSenlinReleaseDates,
 		ReleaseOrder: 5,
 	}
 )

--- a/game/doubutsu_no_mori.go
+++ b/game/doubutsu_no_mori.go
@@ -1,7 +1,10 @@
 package game
 
 import (
+	"time"
+
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
 
@@ -19,9 +22,26 @@ var (
 )
 
 var (
+	// doubutsuNoMoriReleaseDateJapan represents Doubutsu no Mori's release date in Japan.
+	doubutsuNoMoriReleaseDateJapan = nook.ReleaseDate{
+		Day:    14,
+		Month:  time.April,
+		Region: region.Japan,
+		Year:   2001,
+	}
+)
+
+var (
 	// doubutsuNoMoriName contains the localized names of Doubutsu no Mori.
 	doubutsuNoMoriName = nook.Languages{
 		language.AmericanEnglish: doubutsuNoMoriNameAmericanEnglish,
+	}
+)
+
+var (
+	// doubutsuNoMoriReleaseDates contains Doubutsu no Mori's regional release history in chronological order.
+	doubutsuNoMoriReleaseDates = []nook.ReleaseDate{
+		doubutsuNoMoriReleaseDateJapan,
 	}
 )
 
@@ -30,6 +50,7 @@ var (
 	DoubutsuNoMori = nook.Game{
 		Key:          nook.Key(doubutsuNoMori),
 		Name:         doubutsuNoMoriName,
+		ReleaseDates: doubutsuNoMoriReleaseDates,
 		ReleaseOrder: 1,
 	}
 )

--- a/game/doubutsu_no_mori_e_plus.go
+++ b/game/doubutsu_no_mori_e_plus.go
@@ -1,7 +1,10 @@
 package game
 
 import (
+	"time"
+
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
 
@@ -19,9 +22,26 @@ var (
 )
 
 var (
+	// doubutsuNoMoriEPlusReleaseDateJapan represents Doubutsu no Mori e+'s release date in Japan.
+	doubutsuNoMoriEPlusReleaseDateJapan = nook.ReleaseDate{
+		Day:    27,
+		Month:  time.June,
+		Region: region.Japan,
+		Year:   2003,
+	}
+)
+
+var (
 	// doubutsuNoMoriEPlusName contains the localized names of Doubutsu no Mori e+.
 	doubutsuNoMoriEPlusName = nook.Languages{
 		language.AmericanEnglish: doubutsuNoMoriEPlusNameAmericanEnglish,
+	}
+)
+
+var (
+	// doubutsuNoMoriEPlusReleaseDates contains Doubutsu no Mori e+'s regional release history in chronological order.
+	doubutsuNoMoriEPlusReleaseDates = []nook.ReleaseDate{
+		doubutsuNoMoriEPlusReleaseDateJapan,
 	}
 )
 
@@ -30,6 +50,7 @@ var (
 	DoubutsuNoMoriEPlus = nook.Game{
 		Key:          nook.Key(doubutsuNoMoriEPlus),
 		Name:         doubutsuNoMoriEPlusName,
+		ReleaseDates: doubutsuNoMoriEPlusReleaseDates,
 		ReleaseOrder: 4,
 	}
 )

--- a/game/doubutsu_no_mori_plus.go
+++ b/game/doubutsu_no_mori_plus.go
@@ -1,7 +1,10 @@
 package game
 
 import (
+	"time"
+
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
 
@@ -19,9 +22,26 @@ var (
 )
 
 var (
+	// doubutsuNoMoriPlusReleaseDateJapan represents Doubutsu no Mori+'s release date in Japan.
+	doubutsuNoMoriPlusReleaseDateJapan = nook.ReleaseDate{
+		Day:    14,
+		Month:  time.December,
+		Region: region.Japan,
+		Year:   2001,
+	}
+)
+
+var (
 	// doubutsuNoMoriPlusName contains the localized names of Doubutsu no Mori+.
 	doubutsuNoMoriPlusName = nook.Languages{
 		language.AmericanEnglish: doubutsuNoMoriPlusNameAmericanEnglish,
+	}
+)
+
+var (
+	// doubutsuNoMoriPlusReleaseDates contains Doubutsu no Mori+'s regional release history in chronological order.
+	doubutsuNoMoriPlusReleaseDates = []nook.ReleaseDate{
+		doubutsuNoMoriPlusReleaseDateJapan,
 	}
 )
 
@@ -30,6 +50,7 @@ var (
 	DoubutsuNoMoriPlus = nook.Game{
 		Key:          nook.Key(doubutsuNoMoriPlus),
 		Name:         doubutsuNoMoriPlusName,
+		ReleaseDates: doubutsuNoMoriPlusReleaseDates,
 		ReleaseOrder: 2,
 	}
 )

--- a/game/happy_home_designer.go
+++ b/game/happy_home_designer.go
@@ -1,7 +1,10 @@
 package game
 
 import (
+	"time"
+
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
 
@@ -19,9 +22,53 @@ var (
 )
 
 var (
+	// happyHomeDesignerReleaseDateAustralia represents Animal Crossing: Happy Home Designer's release date in Australia.
+	happyHomeDesignerReleaseDateAustralia = nook.ReleaseDate{
+		Day:    3,
+		Month:  time.October,
+		Region: region.Australia,
+		Year:   2015,
+	}
+
+	// happyHomeDesignerReleaseDateEurope represents Animal Crossing: Happy Home Designer's release date in Europe.
+	happyHomeDesignerReleaseDateEurope = nook.ReleaseDate{
+		Day:    2,
+		Month:  time.October,
+		Region: region.Europe,
+		Year:   2015,
+	}
+
+	// happyHomeDesignerReleaseDateJapan represents Animal Crossing: Happy Home Designer's release date in Japan.
+	happyHomeDesignerReleaseDateJapan = nook.ReleaseDate{
+		Day:    30,
+		Month:  time.July,
+		Region: region.Japan,
+		Year:   2015,
+	}
+
+	// happyHomeDesignerReleaseDateNorthAmerica represents Animal Crossing: Happy Home Designer's release date in North America.
+	happyHomeDesignerReleaseDateNorthAmerica = nook.ReleaseDate{
+		Day:    25,
+		Month:  time.September,
+		Region: region.NorthAmerica,
+		Year:   2015,
+	}
+)
+
+var (
 	// happyHomeDesignerName contains the localized names of Animal Crossing: Happy Home Designer.
 	happyHomeDesignerName = nook.Languages{
 		language.AmericanEnglish: happyHomeDesignerNameAmericanEnglish,
+	}
+)
+
+var (
+	// happyHomeDesignerReleaseDates contains Animal Crossing: Happy Home Designer's regional release history in chronological order.
+	happyHomeDesignerReleaseDates = []nook.ReleaseDate{
+		happyHomeDesignerReleaseDateJapan,
+		happyHomeDesignerReleaseDateNorthAmerica,
+		happyHomeDesignerReleaseDateEurope,
+		happyHomeDesignerReleaseDateAustralia,
 	}
 )
 
@@ -30,6 +77,7 @@ var (
 	HappyHomeDesigner = nook.Game{
 		Key:          nook.Key(happyHomeDesigner),
 		Name:         happyHomeDesignerName,
+		ReleaseDates: happyHomeDesignerReleaseDates,
 		ReleaseOrder: 9,
 	}
 )

--- a/game/new_horizons.go
+++ b/game/new_horizons.go
@@ -1,7 +1,10 @@
 package game
 
 import (
+	"time"
+
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
 
@@ -19,9 +22,26 @@ var (
 )
 
 var (
+	// newHorizonsReleaseDateWorldwide represents Animal Crossing: New Horizons' worldwide release date.
+	newHorizonsReleaseDateWorldwide = nook.ReleaseDate{
+		Day:    20,
+		Month:  time.March,
+		Region: region.Worldwide,
+		Year:   2020,
+	}
+)
+
+var (
 	// newHorizonsName contains the localized names of Animal Crossing: New Horizons.
 	newHorizonsName = nook.Languages{
 		language.AmericanEnglish: newHorizonsNameAmericanEnglish,
+	}
+)
+
+var (
+	// newHorizonsReleaseDates contains Animal Crossing: New Horizons' regional release history in chronological order.
+	newHorizonsReleaseDates = []nook.ReleaseDate{
+		newHorizonsReleaseDateWorldwide,
 	}
 )
 
@@ -30,6 +50,7 @@ var (
 	NewHorizons = nook.Game{
 		Key:          nook.Key(newHorizons),
 		Name:         newHorizonsName,
+		ReleaseDates: newHorizonsReleaseDates,
 		ReleaseOrder: 12,
 	}
 )

--- a/game/new_leaf.go
+++ b/game/new_leaf.go
@@ -1,7 +1,10 @@
 package game
 
 import (
+	"time"
+
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
 
@@ -19,9 +22,53 @@ var (
 )
 
 var (
+	// newLeafReleaseDateAustralia represents Animal Crossing: New Leaf's release date in Australia.
+	newLeafReleaseDateAustralia = nook.ReleaseDate{
+		Day:    15,
+		Month:  time.June,
+		Region: region.Australia,
+		Year:   2013,
+	}
+
+	// newLeafReleaseDateEurope represents Animal Crossing: New Leaf's release date in Europe.
+	newLeafReleaseDateEurope = nook.ReleaseDate{
+		Day:    14,
+		Month:  time.June,
+		Region: region.Europe,
+		Year:   2013,
+	}
+
+	// newLeafReleaseDateJapan represents Animal Crossing: New Leaf's release date in Japan.
+	newLeafReleaseDateJapan = nook.ReleaseDate{
+		Day:    8,
+		Month:  time.November,
+		Region: region.Japan,
+		Year:   2012,
+	}
+
+	// newLeafReleaseDateNorthAmerica represents Animal Crossing: New Leaf's release date in North America.
+	newLeafReleaseDateNorthAmerica = nook.ReleaseDate{
+		Day:    9,
+		Month:  time.June,
+		Region: region.NorthAmerica,
+		Year:   2013,
+	}
+)
+
+var (
 	// newLeafName contains the localized names of Animal Crossing: New Leaf.
 	newLeafName = nook.Languages{
 		language.AmericanEnglish: newLeafNameAmericanEnglish,
+	}
+)
+
+var (
+	// newLeafReleaseDates contains Animal Crossing: New Leaf's regional release history in chronological order.
+	newLeafReleaseDates = []nook.ReleaseDate{
+		newLeafReleaseDateJapan,
+		newLeafReleaseDateNorthAmerica,
+		newLeafReleaseDateEurope,
+		newLeafReleaseDateAustralia,
 	}
 )
 
@@ -30,6 +77,7 @@ var (
 	NewLeaf = nook.Game{
 		Key:          nook.Key(newLeaf),
 		Name:         newLeafName,
+		ReleaseDates: newLeafReleaseDates,
 		ReleaseOrder: 8,
 	}
 )

--- a/game/pocket_camp.go
+++ b/game/pocket_camp.go
@@ -1,7 +1,10 @@
 package game
 
 import (
+	"time"
+
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
 
@@ -19,9 +22,35 @@ var (
 )
 
 var (
+	// pocketCampReleaseDateAustralia represents Animal Crossing: Pocket Camp's release date in Australia.
+	pocketCampReleaseDateAustralia = nook.ReleaseDate{
+		Day:    25,
+		Month:  time.October,
+		Region: region.Australia,
+		Year:   2017,
+	}
+
+	// pocketCampReleaseDateWorldwide represents Animal Crossing: Pocket Camp's worldwide release date.
+	pocketCampReleaseDateWorldwide = nook.ReleaseDate{
+		Day:    21,
+		Month:  time.November,
+		Region: region.Worldwide,
+		Year:   2017,
+	}
+)
+
+var (
 	// pocketCampName contains the localized names of Animal Crossing: Pocket Camp.
 	pocketCampName = nook.Languages{
 		language.AmericanEnglish: pocketCampNameAmericanEnglish,
+	}
+)
+
+var (
+	// pocketCampReleaseDates contains Animal Crossing: Pocket Camp's regional release history in chronological order.
+	pocketCampReleaseDates = []nook.ReleaseDate{
+		pocketCampReleaseDateAustralia,
+		pocketCampReleaseDateWorldwide,
 	}
 )
 
@@ -30,6 +59,7 @@ var (
 	PocketCamp = nook.Game{
 		Key:          nook.Key(pocketCamp),
 		Name:         pocketCampName,
+		ReleaseDates: pocketCampReleaseDates,
 		ReleaseOrder: 11,
 	}
 )

--- a/game/registry_test.go
+++ b/game/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/lindsaygelle/nook/game"
+	"github.com/lindsaygelle/nook/region"
 )
 
 func TestByKey(t *testing.T) {
@@ -16,6 +17,9 @@ func TestByKey(t *testing.T) {
 	}
 	if got.ReleaseOrder != 12 {
 		t.Fatalf("game.ByKey(%s).ReleaseOrder = %d", game.NewHorizons.Key, got.ReleaseOrder)
+	}
+	if len(got.ReleaseDates) != 1 {
+		t.Fatalf("len(game.ByKey(%s).ReleaseDates) = %d", game.NewHorizons.Key, len(got.ReleaseDates))
 	}
 }
 
@@ -57,5 +61,45 @@ func TestListReturnsCopy(t *testing.T) {
 	fresh := game.List()
 	if fresh[0].Key != game.DoubutsuNoMori.Key {
 		t.Fatalf("game.List()[0].Key after mutation = %s", fresh[0].Key)
+	}
+}
+
+func TestFirstAndLastReleaseDate(t *testing.T) {
+	first, ok := game.NewLeaf.FirstReleaseDate()
+	if !ok {
+		t.Fatal("game.NewLeaf.FirstReleaseDate() not found")
+	}
+	if first.Region.Key != region.Japan.Key {
+		t.Fatalf("game.NewLeaf.FirstReleaseDate().Region.Key = %s", first.Region.Key)
+	}
+	if first.Year != 2012 || first.Month != 11 || first.Day != 8 {
+		t.Fatalf("game.NewLeaf.FirstReleaseDate() = %#v", first)
+	}
+
+	last, ok := game.NewLeaf.LastReleaseDate()
+	if !ok {
+		t.Fatal("game.NewLeaf.LastReleaseDate() not found")
+	}
+	if last.Region.Key != region.Australia.Key {
+		t.Fatalf("game.NewLeaf.LastReleaseDate().Region.Key = %s", last.Region.Key)
+	}
+	if last.Year != 2013 || last.Month != 6 || last.Day != 15 {
+		t.Fatalf("game.NewLeaf.LastReleaseDate() = %#v", last)
+	}
+}
+
+func TestReleaseDateByRegion(t *testing.T) {
+	releaseDate, ok := game.WildWorld.ReleaseDateByRegion(region.Europe.Key)
+	if !ok {
+		t.Fatalf("game.WildWorld.ReleaseDateByRegion(%s) not found", region.Europe.Key)
+	}
+	if releaseDate.Year != 2006 || releaseDate.Month != 3 || releaseDate.Day != 31 {
+		t.Fatalf("game.WildWorld.ReleaseDateByRegion(%s) = %#v", region.Europe.Key, releaseDate)
+	}
+}
+
+func TestReleaseDateByRegionMissing(t *testing.T) {
+	if _, ok := game.DoubutsuNoMori.ReleaseDateByRegion(region.Europe.Key); ok {
+		t.Fatalf("game.DoubutsuNoMori.ReleaseDateByRegion(%s) unexpectedly found a release date", region.Europe.Key)
 	}
 }

--- a/game/wild_world.go
+++ b/game/wild_world.go
@@ -1,7 +1,10 @@
 package game
 
 import (
+	"time"
+
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
 
@@ -19,9 +22,53 @@ var (
 )
 
 var (
+	// wildWorldReleaseDateAustralia represents Animal Crossing: Wild World's release date in Australia.
+	wildWorldReleaseDateAustralia = nook.ReleaseDate{
+		Day:    8,
+		Month:  time.December,
+		Region: region.Australia,
+		Year:   2005,
+	}
+
+	// wildWorldReleaseDateEurope represents Animal Crossing: Wild World's release date in Europe.
+	wildWorldReleaseDateEurope = nook.ReleaseDate{
+		Day:    31,
+		Month:  time.March,
+		Region: region.Europe,
+		Year:   2006,
+	}
+
+	// wildWorldReleaseDateJapan represents Animal Crossing: Wild World's release date in Japan.
+	wildWorldReleaseDateJapan = nook.ReleaseDate{
+		Day:    23,
+		Month:  time.November,
+		Region: region.Japan,
+		Year:   2005,
+	}
+
+	// wildWorldReleaseDateNorthAmerica represents Animal Crossing: Wild World's release date in North America.
+	wildWorldReleaseDateNorthAmerica = nook.ReleaseDate{
+		Day:    5,
+		Month:  time.December,
+		Region: region.NorthAmerica,
+		Year:   2005,
+	}
+)
+
+var (
 	// wildWorldName contains the localized names of Animal Crossing: Wild World.
 	wildWorldName = nook.Languages{
 		language.AmericanEnglish: wildWorldNameAmericanEnglish,
+	}
+)
+
+var (
+	// wildWorldReleaseDates contains Animal Crossing: Wild World's regional release history in chronological order.
+	wildWorldReleaseDates = []nook.ReleaseDate{
+		wildWorldReleaseDateJapan,
+		wildWorldReleaseDateNorthAmerica,
+		wildWorldReleaseDateAustralia,
+		wildWorldReleaseDateEurope,
 	}
 )
 
@@ -30,6 +77,7 @@ var (
 	WildWorld = nook.Game{
 		Key:          nook.Key(wildWorld),
 		Name:         wildWorldName,
+		ReleaseDates: wildWorldReleaseDates,
 		ReleaseOrder: 6,
 	}
 )

--- a/region.go
+++ b/region.go
@@ -1,0 +1,10 @@
+package nook
+
+// Region represents a major release region in the Animal Crossing series.
+type Region struct {
+	// Key is the language-agnostic key of the region.
+	Key Key
+
+	// Name contains the localized names of the region.
+	Name Languages
+}

--- a/region/australia.go
+++ b/region/australia.go
@@ -1,0 +1,34 @@
+package region
+
+import (
+	"github.com/lindsaygelle/nook"
+	"golang.org/x/text/language"
+)
+
+const (
+	// australia is the common reference for the Australia region.
+	australia = "Australia"
+)
+
+var (
+	// australiaNameAmericanEnglish represents the Australia region's name in American English.
+	australiaNameAmericanEnglish = nook.Name{
+		Language: language.AmericanEnglish,
+		Value:    "Australia",
+	}
+)
+
+var (
+	// australiaName contains the localized names of the Australia region.
+	australiaName = nook.Languages{
+		language.AmericanEnglish: australiaNameAmericanEnglish,
+	}
+)
+
+var (
+	// Australia represents the Australia region in the Animal Crossing series.
+	Australia = nook.Region{
+		Key:  nook.Key(australia),
+		Name: australiaName,
+	}
+)

--- a/region/china.go
+++ b/region/china.go
@@ -1,0 +1,34 @@
+package region
+
+import (
+	"github.com/lindsaygelle/nook"
+	"golang.org/x/text/language"
+)
+
+const (
+	// china is the common reference for the China region.
+	china = "China"
+)
+
+var (
+	// chinaNameAmericanEnglish represents the China region's name in American English.
+	chinaNameAmericanEnglish = nook.Name{
+		Language: language.AmericanEnglish,
+		Value:    "China",
+	}
+)
+
+var (
+	// chinaName contains the localized names of the China region.
+	chinaName = nook.Languages{
+		language.AmericanEnglish: chinaNameAmericanEnglish,
+	}
+)
+
+var (
+	// China represents the China region in the Animal Crossing series.
+	China = nook.Region{
+		Key:  nook.Key(china),
+		Name: chinaName,
+	}
+)

--- a/region/doc.go
+++ b/region/doc.go
@@ -1,0 +1,2 @@
+// Package region contains the canonical Animal Crossing release regions.
+package region

--- a/region/europe.go
+++ b/region/europe.go
@@ -1,0 +1,34 @@
+package region
+
+import (
+	"github.com/lindsaygelle/nook"
+	"golang.org/x/text/language"
+)
+
+const (
+	// europe is the common reference for the Europe region.
+	europe = "Europe"
+)
+
+var (
+	// europeNameAmericanEnglish represents the Europe region's name in American English.
+	europeNameAmericanEnglish = nook.Name{
+		Language: language.AmericanEnglish,
+		Value:    "Europe",
+	}
+)
+
+var (
+	// europeName contains the localized names of the Europe region.
+	europeName = nook.Languages{
+		language.AmericanEnglish: europeNameAmericanEnglish,
+	}
+)
+
+var (
+	// Europe represents the Europe region in the Animal Crossing series.
+	Europe = nook.Region{
+		Key:  nook.Key(europe),
+		Name: europeName,
+	}
+)

--- a/region/japan.go
+++ b/region/japan.go
@@ -1,0 +1,34 @@
+package region
+
+import (
+	"github.com/lindsaygelle/nook"
+	"golang.org/x/text/language"
+)
+
+const (
+	// japan is the common reference for the Japan region.
+	japan = "Japan"
+)
+
+var (
+	// japanNameAmericanEnglish represents the Japan region's name in American English.
+	japanNameAmericanEnglish = nook.Name{
+		Language: language.AmericanEnglish,
+		Value:    "Japan",
+	}
+)
+
+var (
+	// japanName contains the localized names of the Japan region.
+	japanName = nook.Languages{
+		language.AmericanEnglish: japanNameAmericanEnglish,
+	}
+)
+
+var (
+	// Japan represents the Japan region in the Animal Crossing series.
+	Japan = nook.Region{
+		Key:  nook.Key(japan),
+		Name: japanName,
+	}
+)

--- a/region/north_america.go
+++ b/region/north_america.go
@@ -1,0 +1,34 @@
+package region
+
+import (
+	"github.com/lindsaygelle/nook"
+	"golang.org/x/text/language"
+)
+
+const (
+	// northAmerica is the common reference for the North America region.
+	northAmerica = "NorthAmerica"
+)
+
+var (
+	// northAmericaNameAmericanEnglish represents the North America region's name in American English.
+	northAmericaNameAmericanEnglish = nook.Name{
+		Language: language.AmericanEnglish,
+		Value:    "North America",
+	}
+)
+
+var (
+	// northAmericaName contains the localized names of the North America region.
+	northAmericaName = nook.Languages{
+		language.AmericanEnglish: northAmericaNameAmericanEnglish,
+	}
+)
+
+var (
+	// NorthAmerica represents the North America region in the Animal Crossing series.
+	NorthAmerica = nook.Region{
+		Key:  nook.Key(northAmerica),
+		Name: northAmericaName,
+	}
+)

--- a/region/registry.go
+++ b/region/registry.go
@@ -1,0 +1,37 @@
+package region
+
+import "github.com/lindsaygelle/nook"
+
+var (
+	// regions contains the canonical release regions in deterministic key order.
+	regions = []nook.Region{
+		Australia,
+		China,
+		Europe,
+		Japan,
+		NorthAmerica,
+		Worldwide,
+	}
+)
+
+var (
+	// regionsByKey contains canonical release regions indexed by key.
+	regionsByKey = func() map[nook.Key]nook.Region {
+		index := make(map[nook.Key]nook.Region, len(regions))
+		for _, region := range regions {
+			index[region.Key] = region
+		}
+		return index
+	}()
+)
+
+// ByKey returns the canonical release region with the provided key.
+func ByKey(key nook.Key) (nook.Region, bool) {
+	region, ok := regionsByKey[key]
+	return region, ok
+}
+
+// List returns all canonical release regions in deterministic key order.
+func List() []nook.Region {
+	return append([]nook.Region(nil), regions...)
+}

--- a/region/registry_test.go
+++ b/region/registry_test.go
@@ -1,0 +1,46 @@
+package region_test
+
+import (
+	"testing"
+
+	"github.com/lindsaygelle/nook/region"
+)
+
+func TestByKey(t *testing.T) {
+	got, ok := region.ByKey(region.NorthAmerica.Key)
+	if !ok {
+		t.Fatalf("region.ByKey(%s) not found", region.NorthAmerica.Key)
+	}
+	if got.Key != region.NorthAmerica.Key {
+		t.Fatalf("region.ByKey(%s).Key = %s", region.NorthAmerica.Key, got.Key)
+	}
+}
+
+func TestByKeyMissing(t *testing.T) {
+	if _, ok := region.ByKey("missing"); ok {
+		t.Fatal("region.ByKey(missing) unexpectedly found a region")
+	}
+}
+
+func TestList(t *testing.T) {
+	regions := region.List()
+	if len(regions) != 6 {
+		t.Fatalf("len(region.List()) = %d", len(regions))
+	}
+	if regions[0].Key != region.Australia.Key {
+		t.Fatalf("region.List()[0].Key = %s", regions[0].Key)
+	}
+	if regions[len(regions)-1].Key != region.Worldwide.Key {
+		t.Fatalf("region.List()[last].Key = %s", regions[len(regions)-1].Key)
+	}
+}
+
+func TestListReturnsCopy(t *testing.T) {
+	regions := region.List()
+	regions[0] = region.Worldwide
+
+	fresh := region.List()
+	if fresh[0].Key != region.Australia.Key {
+		t.Fatalf("region.List()[0].Key after mutation = %s", fresh[0].Key)
+	}
+}

--- a/region/worldwide.go
+++ b/region/worldwide.go
@@ -1,0 +1,34 @@
+package region
+
+import (
+	"github.com/lindsaygelle/nook"
+	"golang.org/x/text/language"
+)
+
+const (
+	// worldwide is the common reference for the Worldwide region.
+	worldwide = "Worldwide"
+)
+
+var (
+	// worldwideNameAmericanEnglish represents the Worldwide region's name in American English.
+	worldwideNameAmericanEnglish = nook.Name{
+		Language: language.AmericanEnglish,
+		Value:    "Worldwide",
+	}
+)
+
+var (
+	// worldwideName contains the localized names of the Worldwide region.
+	worldwideName = nook.Languages{
+		language.AmericanEnglish: worldwideNameAmericanEnglish,
+	}
+)
+
+var (
+	// Worldwide represents the Worldwide region in the Animal Crossing series.
+	Worldwide = nook.Region{
+		Key:  nook.Key(worldwide),
+		Name: worldwideName,
+	}
+)

--- a/release_date.go
+++ b/release_date.go
@@ -1,0 +1,24 @@
+package nook
+
+import "time"
+
+// ReleaseDate represents a game's release date in a specific region.
+type ReleaseDate struct {
+	// Day is the day of the month when the game released.
+	Day uint8
+
+	// Month is the month of the year when the game released.
+	Month time.Month
+
+	// Region is the major region where the game released on this date.
+	Region Region
+
+	// Year is the year when the game released.
+	Year uint16
+}
+
+// Ok returns a boolean indicating whether the ReleaseDate information is
+// complete and valid.
+func (r ReleaseDate) Ok() bool {
+	return r.Day != 0 && r.Month != 0 && r.Region.Key != "" && r.Year != 0
+}


### PR DESCRIPTION
### Description
Add game-owned regional release metadata so canonical `nook.Game` values carry both their series order and regional release history.

### Related Issue
N/A

### Changes Made
- added canonical `nook.Region` and `nook.ReleaseDate` models, plus a `region` registry package
- extended `nook.Game` with owned `ReleaseDates` data and model-level helpers for first, last, and per-region release lookup
- populated the canonical Animal Crossing game values with regional release dates in the owning `game` package files
- exposed `release_order` and `release_dates` through `catalog.GameRecord`
- added test coverage for region registries, game release-date accessors, and catalog record serialization

### Screenshots (if applicable)
Not applicable.

### How to Test
1. Run `go test ./...`
2. Inspect `game/*.go` to confirm each canonical game owns its release data.
3. Inspect `catalog/record.go` and `catalog/record_test.go` to verify release metadata is exposed through `GameRecord`.

### Checklist
- [x] I have followed the coding style guidelines of the project.
- [x] My code passes all existing unit tests.
- [x] I have added new unit tests to cover the changes where applicable.
- [ ] I have updated the documentation to reflect the changes.
- [x] My changes do not introduce any new warnings or errors.
- [x] I have tested my changes thoroughly.

### Additional Notes
This keeps the release facts owned by the canonical game values rather than introducing a catalog-side lookup table, which keeps the data model self-sufficient for downstream CLI or service usage.
