### PR TITLE
Move character appearance chronology onto nook.Character

### DIFF
--- a/catalog/game.go
+++ b/catalog/game.go
@@ -6,53 +6,13 @@ import (
 	"github.com/lindsaygelle/nook"
 )
 
-func characterAppearsInGame(character nook.Character, gameKey nook.Key) bool {
-	if gameKey == "" {
-		return false
-	}
-
-	for _, appearance := range character.Games {
-		if appearance.Key == gameKey {
-			return true
-		}
-	}
-	return false
-}
-
-func compareGamesByReleaseOrder(a, b nook.Game) int {
-	switch {
-	case a.ReleaseOrder == 0 && b.ReleaseOrder != 0:
-		return 1
-	case a.ReleaseOrder != 0 && b.ReleaseOrder == 0:
-		return -1
-	case a.ReleaseOrder < b.ReleaseOrder:
-		return -1
-	case a.ReleaseOrder > b.ReleaseOrder:
-		return 1
-	}
-	switch {
-	case a.Key < b.Key:
-		return -1
-	case a.Key > b.Key:
-		return 1
-	default:
-		return 0
-	}
-}
-
-func sortedCharacterGames(games []nook.Game) []nook.Game {
-	out := append([]nook.Game(nil), games...)
-	slices.SortFunc(out, compareGamesByReleaseOrder)
-	return out
-}
-
 // CharacterGames returns a character's game appearance history in release
 // order.
 func CharacterGames(character nook.Character) ([]nook.Game, bool) {
 	if character.ID() == "" || character.Games == nil {
 		return nil, false
 	}
-	return sortedCharacterGames(character.Games), true
+	return character.GamesByReleaseOrder(), true
 }
 
 // CharacterGamesByID returns a character's game appearance history using an
@@ -75,11 +35,13 @@ func FirstAppearance(character nook.Character) (nook.Game, bool) {
 // FirstAppearanceByID returns the earliest known game appearance using an
 // exact global character identifier match after normalization.
 func FirstAppearanceByID(id string) (nook.Game, bool) {
-	games, ok := CharacterGamesByID(id)
-	if !ok || len(games) == 0 {
-		return nook.Game{}, false
+	if resident, ok := ResidentByID(id); ok {
+		return resident.Character.FirstGame()
 	}
-	return games[0], true
+	if villager, ok := VillagerByID(id); ok {
+		return villager.Character.FirstGame()
+	}
+	return nook.Game{}, false
 }
 
 // LastAppearance returns the latest known game appearance for a character.
@@ -90,11 +52,13 @@ func LastAppearance(character nook.Character) (nook.Game, bool) {
 // LastAppearanceByID returns the latest known game appearance using an exact
 // global character identifier match after normalization.
 func LastAppearanceByID(id string) (nook.Game, bool) {
-	games, ok := CharacterGamesByID(id)
-	if !ok || len(games) == 0 {
-		return nook.Game{}, false
+	if resident, ok := ResidentByID(id); ok {
+		return resident.Character.LastGame()
 	}
-	return games[len(games)-1], true
+	if villager, ok := VillagerByID(id); ok {
+		return villager.Character.LastGame()
+	}
+	return nook.Game{}, false
 }
 
 // ResidentsByGame returns all residents that appear in the provided game.
@@ -108,7 +72,7 @@ func ResidentsByGame(gameKey nook.Key) []nook.Resident {
 	residents := make([]nook.Resident, 0)
 	for _, bucket := range AllResidents {
 		for _, resident := range bucket {
-			if !characterAppearsInGame(resident.Character, gameKey) {
+			if !resident.Character.AppearsInGame(gameKey) {
 				continue
 			}
 			residents = append(residents, resident)
@@ -130,7 +94,7 @@ func VillagersByGame(gameKey nook.Key) []nook.Villager {
 	villagers := make([]nook.Villager, 0)
 	for _, bucket := range AllVillagers {
 		for _, villager := range bucket {
-			if !characterAppearsInGame(villager.Character, gameKey) {
+			if !villager.Character.AppearsInGame(gameKey) {
 				continue
 			}
 			villagers = append(villagers, villager)

--- a/catalog/record.go
+++ b/catalog/record.go
@@ -112,7 +112,7 @@ func GameRecordOf(game nook.Game) GameRecord {
 
 // CharacterRecordOf converts a domain character into its API-facing record.
 func CharacterRecordOf(character nook.Character) CharacterRecord {
-	games := gameRecordsOf(sortedCharacterGames(character.Games))
+	games := gameRecordsOf(character.GamesByReleaseOrder())
 
 	return CharacterRecord{
 		AnimalKey: string(character.Animal.Key),

--- a/character.go
+++ b/character.go
@@ -1,6 +1,30 @@
 package nook
 
+import "slices"
+
 const characterIDSeparator = ":"
+
+func compareGamesByReleaseOrder(a, b Game) int {
+	switch {
+	case a.ReleaseOrder == 0 && b.ReleaseOrder != 0:
+		return 1
+	case a.ReleaseOrder != 0 && b.ReleaseOrder == 0:
+		return -1
+	case a.ReleaseOrder < b.ReleaseOrder:
+		return -1
+	case a.ReleaseOrder > b.ReleaseOrder:
+		return 1
+	}
+
+	switch {
+	case a.Key < b.Key:
+		return -1
+	case a.Key > b.Key:
+		return 1
+	default:
+		return 0
+	}
+}
 
 // Character is a composite type that combines various attributes of an Animal Crossing character.
 type Character struct {
@@ -30,6 +54,53 @@ type Character struct {
 	Special bool
 }
 
+// AppearsInGame reports whether the character appears in the provided game.
+func (c Character) AppearsInGame(gameKey Key) bool {
+	if gameKey == "" {
+		return false
+	}
+
+	for _, game := range c.Games {
+		if game.Key == gameKey {
+			return true
+		}
+	}
+
+	return false
+}
+
+// FirstGame returns the earliest known game appearance for the character.
+func (c Character) FirstGame() (Game, bool) {
+	games := c.GamesByReleaseOrder()
+	if len(games) == 0 {
+		return Game{}, false
+	}
+	return games[0], true
+}
+
+// GameByKey returns the character's game appearance for the provided game key.
+func (c Character) GameByKey(gameKey Key) (Game, bool) {
+	if gameKey == "" {
+		return Game{}, false
+	}
+
+	for _, game := range c.Games {
+		if game.Key == gameKey {
+			return game, true
+		}
+	}
+
+	return Game{}, false
+}
+
+// GamesByReleaseOrder returns the character's game appearances sorted into
+// deterministic release order.
+func (c Character) GamesByReleaseOrder() []Game {
+	games := append([]Game(nil), c.Games...)
+	slices.SortFunc(games, compareGamesByReleaseOrder)
+	return games
+}
+
 // ID returns a globally unique identifier composed from the character's animal
 // key and character key.
 func (c Character) ID() Key {
@@ -37,4 +108,13 @@ func (c Character) ID() Key {
 		return ""
 	}
 	return Key(string(c.Animal.Key) + characterIDSeparator + string(c.Key))
+}
+
+// LastGame returns the latest known game appearance for the character.
+func (c Character) LastGame() (Game, bool) {
+	games := c.GamesByReleaseOrder()
+	if len(games) == 0 {
+		return Game{}, false
+	}
+	return games[len(games)-1], true
 }

--- a/character_test.go
+++ b/character_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 
 	"github.com/lindsaygelle/nook"
+	catcharacters "github.com/lindsaygelle/nook/character/cat"
+	dogcharacters "github.com/lindsaygelle/nook/character/dog"
+	squirrelcharacters "github.com/lindsaygelle/nook/character/squirrel"
+	"github.com/lindsaygelle/nook/game"
 )
 
 func testCharacter(t *testing.T, animal nook.Key, c nook.Character) {
@@ -53,5 +57,75 @@ func testCharacterGender(t *testing.T, c nook.Character) {
 func testCharacterName(t *testing.T, c nook.Character) {
 	if ok := len(c.Name) != 0; !ok {
 		t.Fatalf("len(%s.Name) == 0", c.Key)
+	}
+}
+
+func TestCharacterAppearsInGame(t *testing.T) {
+	if !catcharacters.Ankha.Character.AppearsInGame(game.NewLeaf.Key) {
+		t.Fatalf("%s.AppearsInGame(%s) = false", catcharacters.Ankha.Key, game.NewLeaf.Key)
+	}
+	if catcharacters.Ankha.Character.AppearsInGame("missing") {
+		t.Fatalf("%s.AppearsInGame(missing) = true", catcharacters.Ankha.Key)
+	}
+}
+
+func TestCharacterFirstAndLastGame(t *testing.T) {
+	first, ok := catcharacters.Ankha.Character.FirstGame()
+	if !ok {
+		t.Fatalf("%s.FirstGame() not found", catcharacters.Ankha.Key)
+	}
+	if first.Key != game.DoubutsuNoMoriPlus.Key {
+		t.Fatalf("%s.FirstGame().Key = %s", catcharacters.Ankha.Key, first.Key)
+	}
+
+	last, ok := dogcharacters.Isabelle.Character.LastGame()
+	if !ok {
+		t.Fatalf("%s.LastGame() not found", dogcharacters.Isabelle.Key)
+	}
+	if last.Key != game.NewHorizons.Key {
+		t.Fatalf("%s.LastGame().Key = %s", dogcharacters.Isabelle.Key, last.Key)
+	}
+}
+
+func TestCharacterGameByKey(t *testing.T) {
+	found, ok := dogcharacters.Isabelle.Character.GameByKey(game.NewLeaf.Key)
+	if !ok {
+		t.Fatalf("%s.GameByKey(%s) not found", dogcharacters.Isabelle.Key, game.NewLeaf.Key)
+	}
+	if found.Key != game.NewLeaf.Key {
+		t.Fatalf("%s.GameByKey(%s).Key = %s", dogcharacters.Isabelle.Key, game.NewLeaf.Key, found.Key)
+	}
+
+	if _, ok := dogcharacters.Isabelle.Character.GameByKey("missing"); ok {
+		t.Fatalf("%s.GameByKey(missing) unexpectedly found a game", dogcharacters.Isabelle.Key)
+	}
+}
+
+func TestCharacterGamesByReleaseOrder(t *testing.T) {
+	games := catcharacters.Ankha.Character.GamesByReleaseOrder()
+	if len(games) != len(catcharacters.Ankha.Character.Games) {
+		t.Fatalf("len(%s.GamesByReleaseOrder()) = %d", catcharacters.Ankha.Key, len(games))
+	}
+	if games[0].Key != game.DoubutsuNoMoriPlus.Key {
+		t.Fatalf("%s.GamesByReleaseOrder()[0].Key = %s", catcharacters.Ankha.Key, games[0].Key)
+	}
+	if games[len(games)-1].Key != game.NewHorizons.Key {
+		t.Fatalf("%s.GamesByReleaseOrder()[last].Key = %s", catcharacters.Ankha.Key, games[len(games)-1].Key)
+	}
+
+	games[0] = game.NewHorizons
+
+	fresh := catcharacters.Ankha.Character.GamesByReleaseOrder()
+	if fresh[0].Key != game.DoubutsuNoMoriPlus.Key {
+		t.Fatalf("%s.GamesByReleaseOrder()[0].Key after mutation = %s", catcharacters.Ankha.Key, fresh[0].Key)
+	}
+}
+
+func TestCharacterGamesWithoutKnownAppearances(t *testing.T) {
+	if _, ok := squirrelcharacters.Shaki.Character.FirstGame(); ok {
+		t.Fatalf("%s.FirstGame() unexpectedly found a game", squirrelcharacters.Shaki.Key)
+	}
+	if _, ok := squirrelcharacters.Shaki.Character.LastGame(); ok {
+		t.Fatalf("%s.LastGame() unexpectedly found a game", squirrelcharacters.Shaki.Key)
 	}
 }


### PR DESCRIPTION
### Description
Move character game-appearance chronology onto the canonical `nook.Character` model and thin the catalog wrappers around it.

### Related Issue
N/A

### Changes Made
- added `nook.Character` helpers for `AppearsInGame`, `GameByKey`, `GamesByReleaseOrder`, `FirstGame`, and `LastGame`
- moved release-order game sorting logic into the root character model so downstream callers can use chronology without going through `catalog`
- simplified `catalog/game.go` and `catalog/record.go` to delegate to the model-level character helpers
- added root-level tests covering the new character appearance methods and copy-safe game ordering

### Screenshots (if applicable)
Not applicable.

### How to Test
1. Run `go test ./...`
2. Inspect `character.go` to verify game-appearance helpers now live on `nook.Character`.
3. Inspect `catalog/game.go` to confirm the catalog layer delegates chronology behavior to the model.

### Checklist
- [x] I have followed the coding style guidelines of the project.
- [x] My code passes all existing unit tests.
- [x] I have added new unit tests to cover the changes where applicable.
- [ ] I have updated the documentation to reflect the changes.
- [x] My changes do not introduce any new warnings or errors.
- [x] I have tested my changes thoroughly.

### Additional Notes
This keeps appearance chronology accessible to any downstream consumer of the Go types, instead of making `catalog` the only place that understands a character's ordered game history.
