### PR TITLE
Add game-owned platform metadata

### DIFF
--- a/catalog/record.go
+++ b/catalog/record.go
@@ -26,10 +26,17 @@ type ReleaseDateRecord struct {
 	Year      uint16          `json:"year"`
 }
 
+// PlatformRecord is a transport-friendly game platform representation.
+type PlatformRecord struct {
+	Key  string          `json:"key"`
+	Name LocalizedValues `json:"name"`
+}
+
 // GameRecord is a transport-friendly game representation.
 type GameRecord struct {
 	Key          string              `json:"key"`
 	Name         LocalizedValues     `json:"name"`
+	Platforms    []PlatformRecord    `json:"platforms"`
 	ReleaseDates []ReleaseDateRecord `json:"release_dates"`
 	ReleaseOrder uint8               `json:"release_order"`
 }
@@ -65,6 +72,21 @@ func gameRecordsOf(games []nook.Game) []GameRecord {
 	records := make([]GameRecord, 0, len(games))
 	for _, game := range games {
 		records = append(records, GameRecordOf(game))
+	}
+	return records
+}
+
+func platformRecordOf(platform nook.Platform) PlatformRecord {
+	return PlatformRecord{
+		Key:  string(platform.Key),
+		Name: LocalizedValuesOf(platform.Name),
+	}
+}
+
+func platformRecordsOf(platforms []nook.Platform) []PlatformRecord {
+	records := make([]PlatformRecord, 0, len(platforms))
+	for _, platform := range platforms {
+		records = append(records, platformRecordOf(platform))
 	}
 	return records
 }
@@ -105,6 +127,7 @@ func GameRecordOf(game nook.Game) GameRecord {
 	return GameRecord{
 		Key:          string(game.Key),
 		Name:         LocalizedValuesOf(game.Name),
+		Platforms:    platformRecordsOf(game.Platforms),
 		ReleaseDates: releaseDateRecordsOf(game.ReleaseDates),
 		ReleaseOrder: game.ReleaseOrder,
 	}

--- a/catalog/record_test.go
+++ b/catalog/record_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lindsaygelle/nook/game"
 	"github.com/lindsaygelle/nook/gender"
 	"github.com/lindsaygelle/nook/personality"
+	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
@@ -29,6 +30,15 @@ func TestGameRecordOf(t *testing.T) {
 	}
 	if record.ReleaseOrder != game.NewLeaf.ReleaseOrder {
 		t.Fatalf("catalog.GameRecordOf(game.NewLeaf).ReleaseOrder = %d", record.ReleaseOrder)
+	}
+	if len(record.Platforms) != 1 {
+		t.Fatalf("len(catalog.GameRecordOf(game.NewLeaf).Platforms) = %d", len(record.Platforms))
+	}
+	if record.Platforms[0].Key != string(platform.Nintendo3DS.Key) {
+		t.Fatalf("catalog.GameRecordOf(game.NewLeaf).Platforms[0].Key = %s", record.Platforms[0].Key)
+	}
+	if record.Platforms[0].Name[language.AmericanEnglish.String()] != "Nintendo 3DS" {
+		t.Fatalf("catalog.GameRecordOf(game.NewLeaf).Platforms[0].Name[en-US] = %s", record.Platforms[0].Name[language.AmericanEnglish.String()])
 	}
 	if len(record.ReleaseDates) != 4 {
 		t.Fatalf("len(catalog.GameRecordOf(game.NewLeaf).ReleaseDates) = %d", len(record.ReleaseDates))

--- a/game.go
+++ b/game.go
@@ -8,6 +8,10 @@ type Game struct {
 	// Name contains the localized names of the game.
 	Name Languages
 
+	// Platforms contains the game's known release platforms in deterministic
+	// key order.
+	Platforms []Platform
+
 	// ReleaseDates contains the game's known regional release history in
 	// chronological order.
 	ReleaseDates []ReleaseDate
@@ -30,6 +34,27 @@ func (g Game) LastReleaseDate() (ReleaseDate, bool) {
 		return ReleaseDate{}, false
 	}
 	return g.ReleaseDates[len(g.ReleaseDates)-1], true
+}
+
+// OnPlatform reports whether the game released on the provided platform.
+func (g Game) OnPlatform(platformKey Key) bool {
+	_, ok := g.PlatformByKey(platformKey)
+	return ok
+}
+
+// PlatformByKey returns the game's platform with the provided key.
+func (g Game) PlatformByKey(platformKey Key) (Platform, bool) {
+	if platformKey == "" {
+		return Platform{}, false
+	}
+
+	for _, platform := range g.Platforms {
+		if platform.Key == platformKey {
+			return platform, true
+		}
+	}
+
+	return Platform{}, false
 }
 
 // ReleaseDateByRegion returns the game's release date for the provided region.

--- a/game/amiibo_festival.go
+++ b/game/amiibo_festival.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
@@ -63,6 +64,13 @@ var (
 )
 
 var (
+	// amiiboFestivalPlatforms contains Animal Crossing: amiibo Festival's release platforms in deterministic key order.
+	amiiboFestivalPlatforms = []nook.Platform{
+		platform.WiiU,
+	}
+)
+
+var (
 	// amiiboFestivalReleaseDates contains Animal Crossing: amiibo Festival's regional release history in chronological order.
 	amiiboFestivalReleaseDates = []nook.ReleaseDate{
 		amiiboFestivalReleaseDateJapan,
@@ -77,6 +85,7 @@ var (
 	AmiiboFestival = nook.Game{
 		Key:          nook.Key(amiiboFestival),
 		Name:         amiiboFestivalName,
+		Platforms:    amiiboFestivalPlatforms,
 		ReleaseDates: amiiboFestivalReleaseDates,
 		ReleaseOrder: 10,
 	}

--- a/game/animal_crossing.go
+++ b/game/animal_crossing.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
@@ -55,6 +56,13 @@ var (
 )
 
 var (
+	// animalCrossingPlatforms contains Animal Crossing's release platforms in deterministic key order.
+	animalCrossingPlatforms = []nook.Platform{
+		platform.GameCube,
+	}
+)
+
+var (
 	// animalCrossingReleaseDates contains Animal Crossing's regional release history in chronological order.
 	animalCrossingReleaseDates = []nook.ReleaseDate{
 		animalCrossingReleaseDateNorthAmerica,
@@ -68,6 +76,7 @@ var (
 	AnimalCrossing = nook.Game{
 		Key:          nook.Key(animalCrossing),
 		Name:         animalCrossingName,
+		Platforms:    animalCrossingPlatforms,
 		ReleaseDates: animalCrossingReleaseDates,
 		ReleaseOrder: 3,
 	}

--- a/game/city_folk.go
+++ b/game/city_folk.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
@@ -63,6 +64,13 @@ var (
 )
 
 var (
+	// cityFolkPlatforms contains Animal Crossing: City Folk's release platforms in deterministic key order.
+	cityFolkPlatforms = []nook.Platform{
+		platform.Wii,
+	}
+)
+
+var (
 	// cityFolkReleaseDates contains Animal Crossing: City Folk's regional release history in chronological order.
 	cityFolkReleaseDates = []nook.ReleaseDate{
 		cityFolkReleaseDateNorthAmerica,
@@ -77,6 +85,7 @@ var (
 	CityFolk = nook.Game{
 		Key:          nook.Key(cityFolk),
 		Name:         cityFolkName,
+		Platforms:    cityFolkPlatforms,
 		ReleaseDates: cityFolkReleaseDates,
 		ReleaseOrder: 7,
 	}

--- a/game/dongwu_senlin.go
+++ b/game/dongwu_senlin.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
@@ -39,6 +40,13 @@ var (
 )
 
 var (
+	// dongwuSenlinPlatforms contains Dongwu Senlin's release platforms in deterministic key order.
+	dongwuSenlinPlatforms = []nook.Platform{
+		platform.IQuePlayer,
+	}
+)
+
+var (
 	// dongwuSenlinReleaseDates contains Dongwu Senlin's regional release history in chronological order.
 	dongwuSenlinReleaseDates = []nook.ReleaseDate{
 		dongwuSenlinReleaseDateChina,
@@ -50,6 +58,7 @@ var (
 	DongwuSenlin = nook.Game{
 		Key:          nook.Key(dongwuSenlin),
 		Name:         dongwuSenlinName,
+		Platforms:    dongwuSenlinPlatforms,
 		ReleaseDates: dongwuSenlinReleaseDates,
 		ReleaseOrder: 5,
 	}

--- a/game/doubutsu_no_mori.go
+++ b/game/doubutsu_no_mori.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
@@ -39,6 +40,13 @@ var (
 )
 
 var (
+	// doubutsuNoMoriPlatforms contains Doubutsu no Mori's release platforms in deterministic key order.
+	doubutsuNoMoriPlatforms = []nook.Platform{
+		platform.Nintendo64,
+	}
+)
+
+var (
 	// doubutsuNoMoriReleaseDates contains Doubutsu no Mori's regional release history in chronological order.
 	doubutsuNoMoriReleaseDates = []nook.ReleaseDate{
 		doubutsuNoMoriReleaseDateJapan,
@@ -50,6 +58,7 @@ var (
 	DoubutsuNoMori = nook.Game{
 		Key:          nook.Key(doubutsuNoMori),
 		Name:         doubutsuNoMoriName,
+		Platforms:    doubutsuNoMoriPlatforms,
 		ReleaseDates: doubutsuNoMoriReleaseDates,
 		ReleaseOrder: 1,
 	}

--- a/game/doubutsu_no_mori_e_plus.go
+++ b/game/doubutsu_no_mori_e_plus.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
@@ -39,6 +40,13 @@ var (
 )
 
 var (
+	// doubutsuNoMoriEPlusPlatforms contains Doubutsu no Mori e+'s release platforms in deterministic key order.
+	doubutsuNoMoriEPlusPlatforms = []nook.Platform{
+		platform.GameCube,
+	}
+)
+
+var (
 	// doubutsuNoMoriEPlusReleaseDates contains Doubutsu no Mori e+'s regional release history in chronological order.
 	doubutsuNoMoriEPlusReleaseDates = []nook.ReleaseDate{
 		doubutsuNoMoriEPlusReleaseDateJapan,
@@ -50,6 +58,7 @@ var (
 	DoubutsuNoMoriEPlus = nook.Game{
 		Key:          nook.Key(doubutsuNoMoriEPlus),
 		Name:         doubutsuNoMoriEPlusName,
+		Platforms:    doubutsuNoMoriEPlusPlatforms,
 		ReleaseDates: doubutsuNoMoriEPlusReleaseDates,
 		ReleaseOrder: 4,
 	}

--- a/game/doubutsu_no_mori_plus.go
+++ b/game/doubutsu_no_mori_plus.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
@@ -39,6 +40,13 @@ var (
 )
 
 var (
+	// doubutsuNoMoriPlusPlatforms contains Doubutsu no Mori+'s release platforms in deterministic key order.
+	doubutsuNoMoriPlusPlatforms = []nook.Platform{
+		platform.GameCube,
+	}
+)
+
+var (
 	// doubutsuNoMoriPlusReleaseDates contains Doubutsu no Mori+'s regional release history in chronological order.
 	doubutsuNoMoriPlusReleaseDates = []nook.ReleaseDate{
 		doubutsuNoMoriPlusReleaseDateJapan,
@@ -50,6 +58,7 @@ var (
 	DoubutsuNoMoriPlus = nook.Game{
 		Key:          nook.Key(doubutsuNoMoriPlus),
 		Name:         doubutsuNoMoriPlusName,
+		Platforms:    doubutsuNoMoriPlusPlatforms,
 		ReleaseDates: doubutsuNoMoriPlusReleaseDates,
 		ReleaseOrder: 2,
 	}

--- a/game/happy_home_designer.go
+++ b/game/happy_home_designer.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
@@ -63,6 +64,13 @@ var (
 )
 
 var (
+	// happyHomeDesignerPlatforms contains Animal Crossing: Happy Home Designer's release platforms in deterministic key order.
+	happyHomeDesignerPlatforms = []nook.Platform{
+		platform.Nintendo3DS,
+	}
+)
+
+var (
 	// happyHomeDesignerReleaseDates contains Animal Crossing: Happy Home Designer's regional release history in chronological order.
 	happyHomeDesignerReleaseDates = []nook.ReleaseDate{
 		happyHomeDesignerReleaseDateJapan,
@@ -77,6 +85,7 @@ var (
 	HappyHomeDesigner = nook.Game{
 		Key:          nook.Key(happyHomeDesigner),
 		Name:         happyHomeDesignerName,
+		Platforms:    happyHomeDesignerPlatforms,
 		ReleaseDates: happyHomeDesignerReleaseDates,
 		ReleaseOrder: 9,
 	}

--- a/game/new_horizons.go
+++ b/game/new_horizons.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
@@ -39,6 +40,13 @@ var (
 )
 
 var (
+	// newHorizonsPlatforms contains Animal Crossing: New Horizons' release platforms in deterministic key order.
+	newHorizonsPlatforms = []nook.Platform{
+		platform.NintendoSwitch,
+	}
+)
+
+var (
 	// newHorizonsReleaseDates contains Animal Crossing: New Horizons' regional release history in chronological order.
 	newHorizonsReleaseDates = []nook.ReleaseDate{
 		newHorizonsReleaseDateWorldwide,
@@ -50,6 +58,7 @@ var (
 	NewHorizons = nook.Game{
 		Key:          nook.Key(newHorizons),
 		Name:         newHorizonsName,
+		Platforms:    newHorizonsPlatforms,
 		ReleaseDates: newHorizonsReleaseDates,
 		ReleaseOrder: 12,
 	}

--- a/game/new_leaf.go
+++ b/game/new_leaf.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
@@ -63,6 +64,13 @@ var (
 )
 
 var (
+	// newLeafPlatforms contains Animal Crossing: New Leaf's release platforms in deterministic key order.
+	newLeafPlatforms = []nook.Platform{
+		platform.Nintendo3DS,
+	}
+)
+
+var (
 	// newLeafReleaseDates contains Animal Crossing: New Leaf's regional release history in chronological order.
 	newLeafReleaseDates = []nook.ReleaseDate{
 		newLeafReleaseDateJapan,
@@ -77,6 +85,7 @@ var (
 	NewLeaf = nook.Game{
 		Key:          nook.Key(newLeaf),
 		Name:         newLeafName,
+		Platforms:    newLeafPlatforms,
 		ReleaseDates: newLeafReleaseDates,
 		ReleaseOrder: 8,
 	}

--- a/game/pocket_camp.go
+++ b/game/pocket_camp.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
@@ -47,6 +48,14 @@ var (
 )
 
 var (
+	// pocketCampPlatforms contains Animal Crossing: Pocket Camp's release platforms in deterministic key order.
+	pocketCampPlatforms = []nook.Platform{
+		platform.Android,
+		platform.IOS,
+	}
+)
+
+var (
 	// pocketCampReleaseDates contains Animal Crossing: Pocket Camp's regional release history in chronological order.
 	pocketCampReleaseDates = []nook.ReleaseDate{
 		pocketCampReleaseDateAustralia,
@@ -59,6 +68,7 @@ var (
 	PocketCamp = nook.Game{
 		Key:          nook.Key(pocketCamp),
 		Name:         pocketCampName,
+		Platforms:    pocketCampPlatforms,
 		ReleaseDates: pocketCampReleaseDates,
 		ReleaseOrder: 11,
 	}

--- a/game/registry_test.go
+++ b/game/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/lindsaygelle/nook/game"
+	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 )
 
@@ -20,6 +21,9 @@ func TestByKey(t *testing.T) {
 	}
 	if len(got.ReleaseDates) != 1 {
 		t.Fatalf("len(game.ByKey(%s).ReleaseDates) = %d", game.NewHorizons.Key, len(got.ReleaseDates))
+	}
+	if len(got.Platforms) != 1 {
+		t.Fatalf("len(game.ByKey(%s).Platforms) = %d", game.NewHorizons.Key, len(got.Platforms))
 	}
 }
 
@@ -101,5 +105,30 @@ func TestReleaseDateByRegion(t *testing.T) {
 func TestReleaseDateByRegionMissing(t *testing.T) {
 	if _, ok := game.DoubutsuNoMori.ReleaseDateByRegion(region.Europe.Key); ok {
 		t.Fatalf("game.DoubutsuNoMori.ReleaseDateByRegion(%s) unexpectedly found a release date", region.Europe.Key)
+	}
+}
+
+func TestOnPlatform(t *testing.T) {
+	if !game.NewHorizons.OnPlatform(platform.NintendoSwitch.Key) {
+		t.Fatalf("game.NewHorizons.OnPlatform(%s) = false", platform.NintendoSwitch.Key)
+	}
+	if game.NewHorizons.OnPlatform(platform.WiiU.Key) {
+		t.Fatalf("game.NewHorizons.OnPlatform(%s) = true", platform.WiiU.Key)
+	}
+}
+
+func TestPlatformByKey(t *testing.T) {
+	found, ok := game.PocketCamp.PlatformByKey(platform.IOS.Key)
+	if !ok {
+		t.Fatalf("game.PocketCamp.PlatformByKey(%s) not found", platform.IOS.Key)
+	}
+	if found.Key != platform.IOS.Key {
+		t.Fatalf("game.PocketCamp.PlatformByKey(%s).Key = %s", platform.IOS.Key, found.Key)
+	}
+}
+
+func TestPlatformByKeyMissing(t *testing.T) {
+	if _, ok := game.CityFolk.PlatformByKey(platform.NintendoSwitch.Key); ok {
+		t.Fatalf("game.CityFolk.PlatformByKey(%s) unexpectedly found a platform", platform.NintendoSwitch.Key)
 	}
 }

--- a/game/wild_world.go
+++ b/game/wild_world.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
 )
@@ -63,6 +64,13 @@ var (
 )
 
 var (
+	// wildWorldPlatforms contains Animal Crossing: Wild World's release platforms in deterministic key order.
+	wildWorldPlatforms = []nook.Platform{
+		platform.NintendoDS,
+	}
+)
+
+var (
 	// wildWorldReleaseDates contains Animal Crossing: Wild World's regional release history in chronological order.
 	wildWorldReleaseDates = []nook.ReleaseDate{
 		wildWorldReleaseDateJapan,
@@ -77,6 +85,7 @@ var (
 	WildWorld = nook.Game{
 		Key:          nook.Key(wildWorld),
 		Name:         wildWorldName,
+		Platforms:    wildWorldPlatforms,
 		ReleaseDates: wildWorldReleaseDates,
 		ReleaseOrder: 6,
 	}

--- a/platform.go
+++ b/platform.go
@@ -1,0 +1,10 @@
+package nook
+
+// Platform represents a game platform in the Animal Crossing series.
+type Platform struct {
+	// Key is the language-agnostic key of the platform.
+	Key Key
+
+	// Name contains the localized names of the platform.
+	Name Languages
+}

--- a/platform/android.go
+++ b/platform/android.go
@@ -1,0 +1,34 @@
+package platform
+
+import (
+	"github.com/lindsaygelle/nook"
+	"golang.org/x/text/language"
+)
+
+const (
+	// android is the common reference for the Android platform.
+	android = "Android"
+)
+
+var (
+	// androidNameAmericanEnglish represents the Android platform's name in American English.
+	androidNameAmericanEnglish = nook.Name{
+		Language: language.AmericanEnglish,
+		Value:    "Android",
+	}
+)
+
+var (
+	// androidName contains the localized names of the Android platform.
+	androidName = nook.Languages{
+		language.AmericanEnglish: androidNameAmericanEnglish,
+	}
+)
+
+var (
+	// Android represents the Android platform in the Animal Crossing series.
+	Android = nook.Platform{
+		Key:  nook.Key(android),
+		Name: androidName,
+	}
+)

--- a/platform/doc.go
+++ b/platform/doc.go
@@ -1,0 +1,2 @@
+// Package platform contains the canonical Animal Crossing game platforms.
+package platform

--- a/platform/game_cube.go
+++ b/platform/game_cube.go
@@ -1,0 +1,34 @@
+package platform
+
+import (
+	"github.com/lindsaygelle/nook"
+	"golang.org/x/text/language"
+)
+
+const (
+	// gameCube is the common reference for the Nintendo GameCube platform.
+	gameCube = "GameCube"
+)
+
+var (
+	// gameCubeNameAmericanEnglish represents the Nintendo GameCube platform's name in American English.
+	gameCubeNameAmericanEnglish = nook.Name{
+		Language: language.AmericanEnglish,
+		Value:    "Nintendo GameCube",
+	}
+)
+
+var (
+	// gameCubeName contains the localized names of the Nintendo GameCube platform.
+	gameCubeName = nook.Languages{
+		language.AmericanEnglish: gameCubeNameAmericanEnglish,
+	}
+)
+
+var (
+	// GameCube represents the Nintendo GameCube platform in the Animal Crossing series.
+	GameCube = nook.Platform{
+		Key:  nook.Key(gameCube),
+		Name: gameCubeName,
+	}
+)

--- a/platform/ios.go
+++ b/platform/ios.go
@@ -1,0 +1,34 @@
+package platform
+
+import (
+	"github.com/lindsaygelle/nook"
+	"golang.org/x/text/language"
+)
+
+const (
+	// ios is the common reference for the iOS platform.
+	ios = "IOS"
+)
+
+var (
+	// iosNameAmericanEnglish represents the iOS platform's name in American English.
+	iosNameAmericanEnglish = nook.Name{
+		Language: language.AmericanEnglish,
+		Value:    "iOS",
+	}
+)
+
+var (
+	// iosName contains the localized names of the iOS platform.
+	iosName = nook.Languages{
+		language.AmericanEnglish: iosNameAmericanEnglish,
+	}
+)
+
+var (
+	// IOS represents the iOS platform in the Animal Crossing series.
+	IOS = nook.Platform{
+		Key:  nook.Key(ios),
+		Name: iosName,
+	}
+)

--- a/platform/ique_player.go
+++ b/platform/ique_player.go
@@ -1,0 +1,34 @@
+package platform
+
+import (
+	"github.com/lindsaygelle/nook"
+	"golang.org/x/text/language"
+)
+
+const (
+	// iQuePlayer is the common reference for the iQue Player platform.
+	iQuePlayer = "IQuePlayer"
+)
+
+var (
+	// iQuePlayerNameAmericanEnglish represents the iQue Player platform's name in American English.
+	iQuePlayerNameAmericanEnglish = nook.Name{
+		Language: language.AmericanEnglish,
+		Value:    "iQue Player",
+	}
+)
+
+var (
+	// iQuePlayerName contains the localized names of the iQue Player platform.
+	iQuePlayerName = nook.Languages{
+		language.AmericanEnglish: iQuePlayerNameAmericanEnglish,
+	}
+)
+
+var (
+	// IQuePlayer represents the iQue Player platform in the Animal Crossing series.
+	IQuePlayer = nook.Platform{
+		Key:  nook.Key(iQuePlayer),
+		Name: iQuePlayerName,
+	}
+)

--- a/platform/nintendo_3ds.go
+++ b/platform/nintendo_3ds.go
@@ -1,0 +1,34 @@
+package platform
+
+import (
+	"github.com/lindsaygelle/nook"
+	"golang.org/x/text/language"
+)
+
+const (
+	// nintendo3DS is the common reference for the Nintendo 3DS platform.
+	nintendo3DS = "Nintendo3DS"
+)
+
+var (
+	// nintendo3DSNameAmericanEnglish represents the Nintendo 3DS platform's name in American English.
+	nintendo3DSNameAmericanEnglish = nook.Name{
+		Language: language.AmericanEnglish,
+		Value:    "Nintendo 3DS",
+	}
+)
+
+var (
+	// nintendo3DSName contains the localized names of the Nintendo 3DS platform.
+	nintendo3DSName = nook.Languages{
+		language.AmericanEnglish: nintendo3DSNameAmericanEnglish,
+	}
+)
+
+var (
+	// Nintendo3DS represents the Nintendo 3DS platform in the Animal Crossing series.
+	Nintendo3DS = nook.Platform{
+		Key:  nook.Key(nintendo3DS),
+		Name: nintendo3DSName,
+	}
+)

--- a/platform/nintendo_64.go
+++ b/platform/nintendo_64.go
@@ -1,0 +1,34 @@
+package platform
+
+import (
+	"github.com/lindsaygelle/nook"
+	"golang.org/x/text/language"
+)
+
+const (
+	// nintendo64 is the common reference for the Nintendo 64 platform.
+	nintendo64 = "Nintendo64"
+)
+
+var (
+	// nintendo64NameAmericanEnglish represents the Nintendo 64 platform's name in American English.
+	nintendo64NameAmericanEnglish = nook.Name{
+		Language: language.AmericanEnglish,
+		Value:    "Nintendo 64",
+	}
+)
+
+var (
+	// nintendo64Name contains the localized names of the Nintendo 64 platform.
+	nintendo64Name = nook.Languages{
+		language.AmericanEnglish: nintendo64NameAmericanEnglish,
+	}
+)
+
+var (
+	// Nintendo64 represents the Nintendo 64 platform in the Animal Crossing series.
+	Nintendo64 = nook.Platform{
+		Key:  nook.Key(nintendo64),
+		Name: nintendo64Name,
+	}
+)

--- a/platform/nintendo_ds.go
+++ b/platform/nintendo_ds.go
@@ -1,0 +1,34 @@
+package platform
+
+import (
+	"github.com/lindsaygelle/nook"
+	"golang.org/x/text/language"
+)
+
+const (
+	// nintendoDS is the common reference for the Nintendo DS platform.
+	nintendoDS = "NintendoDS"
+)
+
+var (
+	// nintendoDSNameAmericanEnglish represents the Nintendo DS platform's name in American English.
+	nintendoDSNameAmericanEnglish = nook.Name{
+		Language: language.AmericanEnglish,
+		Value:    "Nintendo DS",
+	}
+)
+
+var (
+	// nintendoDSName contains the localized names of the Nintendo DS platform.
+	nintendoDSName = nook.Languages{
+		language.AmericanEnglish: nintendoDSNameAmericanEnglish,
+	}
+)
+
+var (
+	// NintendoDS represents the Nintendo DS platform in the Animal Crossing series.
+	NintendoDS = nook.Platform{
+		Key:  nook.Key(nintendoDS),
+		Name: nintendoDSName,
+	}
+)

--- a/platform/nintendo_switch.go
+++ b/platform/nintendo_switch.go
@@ -1,0 +1,34 @@
+package platform
+
+import (
+	"github.com/lindsaygelle/nook"
+	"golang.org/x/text/language"
+)
+
+const (
+	// nintendoSwitch is the common reference for the Nintendo Switch platform.
+	nintendoSwitch = "NintendoSwitch"
+)
+
+var (
+	// nintendoSwitchNameAmericanEnglish represents the Nintendo Switch platform's name in American English.
+	nintendoSwitchNameAmericanEnglish = nook.Name{
+		Language: language.AmericanEnglish,
+		Value:    "Nintendo Switch",
+	}
+)
+
+var (
+	// nintendoSwitchName contains the localized names of the Nintendo Switch platform.
+	nintendoSwitchName = nook.Languages{
+		language.AmericanEnglish: nintendoSwitchNameAmericanEnglish,
+	}
+)
+
+var (
+	// NintendoSwitch represents the Nintendo Switch platform in the Animal Crossing series.
+	NintendoSwitch = nook.Platform{
+		Key:  nook.Key(nintendoSwitch),
+		Name: nintendoSwitchName,
+	}
+)

--- a/platform/registry.go
+++ b/platform/registry.go
@@ -1,0 +1,41 @@
+package platform
+
+import "github.com/lindsaygelle/nook"
+
+var (
+	// platforms contains the canonical game platforms in deterministic key order.
+	platforms = []nook.Platform{
+		Android,
+		GameCube,
+		IOS,
+		IQuePlayer,
+		Nintendo3DS,
+		Nintendo64,
+		NintendoDS,
+		NintendoSwitch,
+		Wii,
+		WiiU,
+	}
+)
+
+var (
+	// platformsByKey contains canonical game platforms indexed by key.
+	platformsByKey = func() map[nook.Key]nook.Platform {
+		index := make(map[nook.Key]nook.Platform, len(platforms))
+		for _, platform := range platforms {
+			index[platform.Key] = platform
+		}
+		return index
+	}()
+)
+
+// ByKey returns the canonical game platform with the provided key.
+func ByKey(key nook.Key) (nook.Platform, bool) {
+	platform, ok := platformsByKey[key]
+	return platform, ok
+}
+
+// List returns all canonical game platforms in deterministic key order.
+func List() []nook.Platform {
+	return append([]nook.Platform(nil), platforms...)
+}

--- a/platform/registry_test.go
+++ b/platform/registry_test.go
@@ -1,0 +1,46 @@
+package platform_test
+
+import (
+	"testing"
+
+	"github.com/lindsaygelle/nook/platform"
+)
+
+func TestByKey(t *testing.T) {
+	got, ok := platform.ByKey(platform.NintendoSwitch.Key)
+	if !ok {
+		t.Fatalf("platform.ByKey(%s) not found", platform.NintendoSwitch.Key)
+	}
+	if got.Key != platform.NintendoSwitch.Key {
+		t.Fatalf("platform.ByKey(%s).Key = %s", platform.NintendoSwitch.Key, got.Key)
+	}
+}
+
+func TestByKeyMissing(t *testing.T) {
+	if _, ok := platform.ByKey("missing"); ok {
+		t.Fatal("platform.ByKey(missing) unexpectedly found a platform")
+	}
+}
+
+func TestList(t *testing.T) {
+	platforms := platform.List()
+	if len(platforms) != 10 {
+		t.Fatalf("len(platform.List()) = %d", len(platforms))
+	}
+	if platforms[0].Key != platform.Android.Key {
+		t.Fatalf("platform.List()[0].Key = %s", platforms[0].Key)
+	}
+	if platforms[len(platforms)-1].Key != platform.WiiU.Key {
+		t.Fatalf("platform.List()[last].Key = %s", platforms[len(platforms)-1].Key)
+	}
+}
+
+func TestListReturnsCopy(t *testing.T) {
+	platforms := platform.List()
+	platforms[0] = platform.WiiU
+
+	fresh := platform.List()
+	if fresh[0].Key != platform.Android.Key {
+		t.Fatalf("platform.List()[0].Key after mutation = %s", fresh[0].Key)
+	}
+}

--- a/platform/wii.go
+++ b/platform/wii.go
@@ -1,0 +1,34 @@
+package platform
+
+import (
+	"github.com/lindsaygelle/nook"
+	"golang.org/x/text/language"
+)
+
+const (
+	// wii is the common reference for the Wii platform.
+	wii = "Wii"
+)
+
+var (
+	// wiiNameAmericanEnglish represents the Wii platform's name in American English.
+	wiiNameAmericanEnglish = nook.Name{
+		Language: language.AmericanEnglish,
+		Value:    "Wii",
+	}
+)
+
+var (
+	// wiiName contains the localized names of the Wii platform.
+	wiiName = nook.Languages{
+		language.AmericanEnglish: wiiNameAmericanEnglish,
+	}
+)
+
+var (
+	// Wii represents the Wii platform in the Animal Crossing series.
+	Wii = nook.Platform{
+		Key:  nook.Key(wii),
+		Name: wiiName,
+	}
+)

--- a/platform/wii_u.go
+++ b/platform/wii_u.go
@@ -1,0 +1,34 @@
+package platform
+
+import (
+	"github.com/lindsaygelle/nook"
+	"golang.org/x/text/language"
+)
+
+const (
+	// wiiU is the common reference for the Wii U platform.
+	wiiU = "WiiU"
+)
+
+var (
+	// wiiUNameAmericanEnglish represents the Wii U platform's name in American English.
+	wiiUNameAmericanEnglish = nook.Name{
+		Language: language.AmericanEnglish,
+		Value:    "Wii U",
+	}
+)
+
+var (
+	// wiiUName contains the localized names of the Wii U platform.
+	wiiUName = nook.Languages{
+		language.AmericanEnglish: wiiUNameAmericanEnglish,
+	}
+)
+
+var (
+	// WiiU represents the Wii U platform in the Animal Crossing series.
+	WiiU = nook.Platform{
+		Key:  nook.Key(wiiU),
+		Name: wiiUName,
+	}
+)


### PR DESCRIPTION
### Description
Add canonical game platform metadata owned directly by `nook.Game` and expose it through the record layer.

### Related Issue
N/A

### Changes Made
- added canonical `nook.Platform` plus a `platform` registry package for Animal Crossing game platforms
- extended `nook.Game` with owned `Platforms` data and model-level helpers for `OnPlatform` and `PlatformByKey`
- populated each canonical game value with its release platform facts in the owning `game/*.go` files
- exposed `platforms` through `catalog.GameRecord`
- added test coverage for platform registries, game platform helpers, and transport record serialization

### Screenshots (if applicable)
Not applicable.

### How to Test
1. Run `go test ./...`
2. Inspect `game/*.go` to confirm each canonical game owns its platform data.
3. Inspect `platform/` to verify the canonical platform registry.
4. Inspect `catalog/record.go` and `catalog/record_test.go` to verify platform metadata is exposed through `GameRecord`.

### Checklist
- [x] I have followed the coding style guidelines of the project.
- [x] My code passes all existing unit tests.
- [x] I have added new unit tests to cover the changes where applicable.
- [ ] I have updated the documentation to reflect the changes.
- [x] My changes do not introduce any new warnings or errors.
- [x] I have tested my changes thoroughly.

### Additional Notes
This keeps another useful series fact on the canonical game model itself rather than requiring downstream consumers to maintain their own platform lookup tables.
