### PR TITLE
Add character-owned release date helpers

### DIFF
--- a/catalog/record.go
+++ b/catalog/record.go
@@ -43,16 +43,18 @@ type GameRecord struct {
 
 // CharacterRecord is a flattened API-facing representation of a character.
 type CharacterRecord struct {
-	AnimalKey string          `json:"animal_key"`
-	Birthday  BirthdayRecord  `json:"birthday"`
-	Code      string          `json:"code,omitempty"`
-	Games     []GameRecord    `json:"games"`
-	Gender    LocalizedValues `json:"gender"`
-	GenderKey string          `json:"gender_key"`
-	ID        string          `json:"id"`
-	Key       string          `json:"key"`
-	Name      LocalizedValues `json:"name"`
-	Special   bool            `json:"special"`
+	AnimalKey        string             `json:"animal_key"`
+	Birthday         BirthdayRecord     `json:"birthday"`
+	Code             string             `json:"code,omitempty"`
+	FirstReleaseDate *ReleaseDateRecord `json:"first_release_date,omitempty"`
+	Games            []GameRecord       `json:"games"`
+	Gender           LocalizedValues    `json:"gender"`
+	GenderKey        string             `json:"gender_key"`
+	ID               string             `json:"id"`
+	Key              string             `json:"key"`
+	LastReleaseDate  *ReleaseDateRecord `json:"last_release_date,omitempty"`
+	Name             LocalizedValues    `json:"name"`
+	Special          bool               `json:"special"`
 }
 
 // ResidentRecord is an API-facing representation of a resident.
@@ -109,6 +111,15 @@ func releaseDateRecordsOf(releaseDates []nook.ReleaseDate) []ReleaseDateRecord {
 	return records
 }
 
+func releaseDateRecordPointerOf(releaseDate nook.ReleaseDate, ok bool) *ReleaseDateRecord {
+	if !ok {
+		return nil
+	}
+
+	record := releaseDateRecordOf(releaseDate)
+	return &record
+}
+
 // LocalizedValuesOf converts language-tagged values into a transport-friendly
 // map and omits empty values.
 func LocalizedValuesOf(values nook.Languages) LocalizedValues {
@@ -143,14 +154,16 @@ func CharacterRecordOf(character nook.Character) CharacterRecord {
 			Day:   character.Birthday.Day,
 			Month: uint8(character.Birthday.Month),
 		},
-		Code:      character.Code.Value,
-		Games:     games,
-		Gender:    LocalizedValuesOf(character.Gender.Name),
-		GenderKey: string(character.Gender.Key),
-		ID:        string(character.ID()),
-		Key:       string(character.Key),
-		Name:      LocalizedValuesOf(character.Name),
-		Special:   character.Special,
+		Code:             character.Code.Value,
+		FirstReleaseDate: releaseDateRecordPointerOf(character.FirstReleaseDate()),
+		Games:            games,
+		Gender:           LocalizedValuesOf(character.Gender.Name),
+		GenderKey:        string(character.Gender.Key),
+		ID:               string(character.ID()),
+		Key:              string(character.Key),
+		LastReleaseDate:  releaseDateRecordPointerOf(character.LastReleaseDate()),
+		Name:             LocalizedValuesOf(character.Name),
+		Special:          character.Special,
 	}
 }
 

--- a/catalog/record_test.go
+++ b/catalog/record_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lindsaygelle/nook/character/dog"
 	"github.com/lindsaygelle/nook/character/mouse"
 	"github.com/lindsaygelle/nook/character/raccoon"
+	"github.com/lindsaygelle/nook/character/squirrel"
 	"github.com/lindsaygelle/nook/game"
 	"github.com/lindsaygelle/nook/gender"
 	"github.com/lindsaygelle/nook/personality"
@@ -75,6 +76,12 @@ func TestCharacterRecordOf(t *testing.T) {
 	if record.Name[language.AmericanEnglish.String()] != "Ankha" {
 		t.Fatalf("catalog.CharacterRecordOf(cat.Ankha).Name[en-US] = %s", record.Name[language.AmericanEnglish.String()])
 	}
+	if record.FirstReleaseDate == nil {
+		t.Fatal("catalog.CharacterRecordOf(cat.Ankha).FirstReleaseDate unexpectedly nil")
+	}
+	if record.FirstReleaseDate.Year != 2001 || record.FirstReleaseDate.Month != 12 || record.FirstReleaseDate.Day != 14 {
+		t.Fatalf("catalog.CharacterRecordOf(cat.Ankha).FirstReleaseDate = %#v", record.FirstReleaseDate)
+	}
 	if len(record.Games) != 9 {
 		t.Fatalf("len(catalog.CharacterRecordOf(cat.Ankha).Games) = %d", len(record.Games))
 	}
@@ -83,6 +90,23 @@ func TestCharacterRecordOf(t *testing.T) {
 	}
 	if record.Games[len(record.Games)-1].Key != string(game.NewHorizons.Key) {
 		t.Fatalf("catalog.CharacterRecordOf(cat.Ankha).Games[last].Key = %s", record.Games[len(record.Games)-1].Key)
+	}
+	if record.LastReleaseDate == nil {
+		t.Fatal("catalog.CharacterRecordOf(cat.Ankha).LastReleaseDate unexpectedly nil")
+	}
+	if record.LastReleaseDate.Year != 2020 || record.LastReleaseDate.Month != 3 || record.LastReleaseDate.Day != 20 {
+		t.Fatalf("catalog.CharacterRecordOf(cat.Ankha).LastReleaseDate = %#v", record.LastReleaseDate)
+	}
+}
+
+func TestCharacterRecordOfWithoutReleaseDates(t *testing.T) {
+	record := catalog.CharacterRecordOf(squirrel.Shaki.Character)
+
+	if record.FirstReleaseDate != nil {
+		t.Fatalf("catalog.CharacterRecordOf(squirrel.Shaki).FirstReleaseDate = %#v", record.FirstReleaseDate)
+	}
+	if record.LastReleaseDate != nil {
+		t.Fatalf("catalog.CharacterRecordOf(squirrel.Shaki).LastReleaseDate = %#v", record.LastReleaseDate)
 	}
 }
 

--- a/character.go
+++ b/character.go
@@ -78,6 +78,15 @@ func (c Character) FirstGame() (Game, bool) {
 	return games[0], true
 }
 
+// FirstReleaseDate returns the earliest known release date for the character.
+func (c Character) FirstReleaseDate() (ReleaseDate, bool) {
+	game, ok := c.FirstGame()
+	if !ok {
+		return ReleaseDate{}, false
+	}
+	return game.FirstReleaseDate()
+}
+
 // GameByKey returns the character's game appearance for the provided game key.
 func (c Character) GameByKey(gameKey Key) (Game, bool) {
 	if gameKey == "" {
@@ -91,6 +100,38 @@ func (c Character) GameByKey(gameKey Key) (Game, bool) {
 	}
 
 	return Game{}, false
+}
+
+// GamesOnPlatform returns a boolean indicating whether the character appears on
+// the provided platform in any known game appearance.
+func (c Character) GamesOnPlatform(platformKey Key) bool {
+	if platformKey == "" {
+		return false
+	}
+
+	for _, game := range c.Games {
+		if game.OnPlatform(platformKey) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// GamesReleasedInRegion returns a boolean indicating whether the character
+// appears in any game that released in the provided region.
+func (c Character) GamesReleasedInRegion(regionKey Key) bool {
+	if regionKey == "" {
+		return false
+	}
+
+	for _, game := range c.Games {
+		if _, ok := game.ReleaseDateByRegion(regionKey); ok {
+			return true
+		}
+	}
+
+	return false
 }
 
 // GamesByReleaseOrder returns the character's game appearances sorted into
@@ -117,4 +158,13 @@ func (c Character) LastGame() (Game, bool) {
 		return Game{}, false
 	}
 	return games[len(games)-1], true
+}
+
+// LastReleaseDate returns the latest known release date for the character.
+func (c Character) LastReleaseDate() (ReleaseDate, bool) {
+	game, ok := c.LastGame()
+	if !ok {
+		return ReleaseDate{}, false
+	}
+	return game.LastReleaseDate()
 }

--- a/character_test.go
+++ b/character_test.go
@@ -9,6 +9,8 @@ import (
 	dogcharacters "github.com/lindsaygelle/nook/character/dog"
 	squirrelcharacters "github.com/lindsaygelle/nook/character/squirrel"
 	"github.com/lindsaygelle/nook/game"
+	"github.com/lindsaygelle/nook/platform"
+	"github.com/lindsaygelle/nook/region"
 )
 
 func testCharacter(t *testing.T, animal nook.Key, c nook.Character) {
@@ -87,6 +89,24 @@ func TestCharacterFirstAndLastGame(t *testing.T) {
 	}
 }
 
+func TestCharacterFirstAndLastReleaseDate(t *testing.T) {
+	first, ok := catcharacters.Ankha.Character.FirstReleaseDate()
+	if !ok {
+		t.Fatalf("%s.FirstReleaseDate() not found", catcharacters.Ankha.Key)
+	}
+	if first.Year != 2001 || first.Month != 12 || first.Day != 14 {
+		t.Fatalf("%s.FirstReleaseDate() = %#v", catcharacters.Ankha.Key, first)
+	}
+
+	last, ok := dogcharacters.Isabelle.Character.LastReleaseDate()
+	if !ok {
+		t.Fatalf("%s.LastReleaseDate() not found", dogcharacters.Isabelle.Key)
+	}
+	if last.Year != 2020 || last.Month != 3 || last.Day != 20 {
+		t.Fatalf("%s.LastReleaseDate() = %#v", dogcharacters.Isabelle.Key, last)
+	}
+}
+
 func TestCharacterGameByKey(t *testing.T) {
 	found, ok := dogcharacters.Isabelle.Character.GameByKey(game.NewLeaf.Key)
 	if !ok {
@@ -121,11 +141,35 @@ func TestCharacterGamesByReleaseOrder(t *testing.T) {
 	}
 }
 
+func TestCharacterGamesOnPlatform(t *testing.T) {
+	if !dogcharacters.Isabelle.Character.GamesOnPlatform(platform.Nintendo3DS.Key) {
+		t.Fatalf("%s.GamesOnPlatform(%s) = false", dogcharacters.Isabelle.Key, platform.Nintendo3DS.Key)
+	}
+	if dogcharacters.Isabelle.Character.GamesOnPlatform(platform.Nintendo64.Key) {
+		t.Fatalf("%s.GamesOnPlatform(%s) = true", dogcharacters.Isabelle.Key, platform.Nintendo64.Key)
+	}
+}
+
+func TestCharacterGamesReleasedInRegion(t *testing.T) {
+	if !dogcharacters.Isabelle.Character.GamesReleasedInRegion(region.Japan.Key) {
+		t.Fatalf("%s.GamesReleasedInRegion(%s) = false", dogcharacters.Isabelle.Key, region.Japan.Key)
+	}
+	if catcharacters.Ankha.Character.GamesReleasedInRegion(region.China.Key) {
+		t.Fatalf("%s.GamesReleasedInRegion(%s) = true", catcharacters.Ankha.Key, region.China.Key)
+	}
+}
+
 func TestCharacterGamesWithoutKnownAppearances(t *testing.T) {
 	if _, ok := squirrelcharacters.Shaki.Character.FirstGame(); ok {
 		t.Fatalf("%s.FirstGame() unexpectedly found a game", squirrelcharacters.Shaki.Key)
 	}
 	if _, ok := squirrelcharacters.Shaki.Character.LastGame(); ok {
 		t.Fatalf("%s.LastGame() unexpectedly found a game", squirrelcharacters.Shaki.Key)
+	}
+	if _, ok := squirrelcharacters.Shaki.Character.FirstReleaseDate(); ok {
+		t.Fatalf("%s.FirstReleaseDate() unexpectedly found a release date", squirrelcharacters.Shaki.Key)
+	}
+	if _, ok := squirrelcharacters.Shaki.Character.LastReleaseDate(); ok {
+		t.Fatalf("%s.LastReleaseDate() unexpectedly found a release date", squirrelcharacters.Shaki.Key)
 	}
 }


### PR DESCRIPTION
### Description
Add character-owned release-date helpers and expose earliest/latest known release dates through the API-facing character records.

### Related Issue
N/A

### Changes Made
- added `nook.Character` helpers for `FirstReleaseDate`, `LastReleaseDate`, `GamesOnPlatform`, and `GamesReleasedInRegion`
- kept the chronology logic on the root model so downstream consumers can reason about character release history without going through `catalog`
- extended `catalog.CharacterRecord` with optional `first_release_date` and `last_release_date` fields
- added tests covering character release-date/platform/region helpers and record serialization for characters with and without known release history

### Screenshots (if applicable)
Not applicable.

### How to Test
1. Run `go test ./...`
2. Inspect `character.go` to verify the release-date and platform/region helpers live on `nook.Character`.
3. Inspect `catalog/record.go` and `catalog/record_test.go` to confirm earliest/latest release dates are exposed through `CharacterRecord`.

### Checklist
- [x] I have followed the coding style guidelines of the project.
- [x] My code passes all existing unit tests.
- [x] I have added new unit tests to cover the changes where applicable.
- [ ] I have updated the documentation to reflect the changes.
- [x] My changes do not introduce any new warnings or errors.
- [x] I have tested my changes thoroughly.

### Additional Notes
This continues the ownership shift away from catalog-only chronology behavior by making character release history directly accessible from the canonical Go model values.
