### PR TITLE
Add game-owned category metadata

### DIFF
--- a/catalog/record.go
+++ b/catalog/record.go
@@ -32,8 +32,15 @@ type PlatformRecord struct {
 	Name LocalizedValues `json:"name"`
 }
 
+// GameCategoryRecord is a transport-friendly game category representation.
+type GameCategoryRecord struct {
+	Key  string          `json:"key"`
+	Name LocalizedValues `json:"name"`
+}
+
 // GameRecord is a transport-friendly game representation.
 type GameRecord struct {
+	Category     GameCategoryRecord  `json:"category"`
 	Key          string              `json:"key"`
 	Name         LocalizedValues     `json:"name"`
 	Platforms    []PlatformRecord    `json:"platforms"`
@@ -76,6 +83,13 @@ func gameRecordsOf(games []nook.Game) []GameRecord {
 		records = append(records, GameRecordOf(game))
 	}
 	return records
+}
+
+func gameCategoryRecordOf(category nook.GameCategory) GameCategoryRecord {
+	return GameCategoryRecord{
+		Key:  string(category.Key),
+		Name: LocalizedValuesOf(category.Name),
+	}
 }
 
 func platformRecordOf(platform nook.Platform) PlatformRecord {
@@ -136,6 +150,7 @@ func LocalizedValuesOf(values nook.Languages) LocalizedValues {
 // GameRecordOf converts a domain game into its API-facing record.
 func GameRecordOf(game nook.Game) GameRecord {
 	return GameRecord{
+		Category:     gameCategoryRecordOf(game.Category),
 		Key:          string(game.Key),
 		Name:         LocalizedValuesOf(game.Name),
 		Platforms:    platformRecordsOf(game.Platforms),

--- a/catalog/record_test.go
+++ b/catalog/record_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lindsaygelle/nook/character/raccoon"
 	"github.com/lindsaygelle/nook/character/squirrel"
 	"github.com/lindsaygelle/nook/game"
+	"github.com/lindsaygelle/nook/gamecategory"
 	"github.com/lindsaygelle/nook/gender"
 	"github.com/lindsaygelle/nook/personality"
 	"github.com/lindsaygelle/nook/platform"
@@ -31,6 +32,12 @@ func TestGameRecordOf(t *testing.T) {
 	}
 	if record.ReleaseOrder != game.NewLeaf.ReleaseOrder {
 		t.Fatalf("catalog.GameRecordOf(game.NewLeaf).ReleaseOrder = %d", record.ReleaseOrder)
+	}
+	if record.Category.Key != string(gamecategory.Mainline.Key) {
+		t.Fatalf("catalog.GameRecordOf(game.NewLeaf).Category.Key = %s", record.Category.Key)
+	}
+	if record.Category.Name[language.AmericanEnglish.String()] != "Mainline" {
+		t.Fatalf("catalog.GameRecordOf(game.NewLeaf).Category.Name[en-US] = %s", record.Category.Name[language.AmericanEnglish.String()])
 	}
 	if len(record.Platforms) != 1 {
 		t.Fatalf("len(catalog.GameRecordOf(game.NewLeaf).Platforms) = %d", len(record.Platforms))

--- a/game.go
+++ b/game.go
@@ -2,6 +2,9 @@ package nook
 
 // Game represents a game in the Animal Crossing series.
 type Game struct {
+	// Category describes the game's series classification.
+	Category GameCategory
+
 	// Key is the language-agnostic key of the game.
 	Key Key
 
@@ -36,10 +39,25 @@ func (g Game) LastReleaseDate() (ReleaseDate, bool) {
 	return g.ReleaseDates[len(g.ReleaseDates)-1], true
 }
 
+// HasCategory reports whether the game belongs to the provided category.
+func (g Game) HasCategory(categoryKey Key) bool {
+	_, ok := g.CategoryByKey(categoryKey)
+	return ok
+}
+
 // OnPlatform reports whether the game released on the provided platform.
 func (g Game) OnPlatform(platformKey Key) bool {
 	_, ok := g.PlatformByKey(platformKey)
 	return ok
+}
+
+// CategoryByKey returns the game's category with the provided key.
+func (g Game) CategoryByKey(categoryKey Key) (GameCategory, bool) {
+	if categoryKey == "" || g.Category.Key != categoryKey {
+		return GameCategory{}, false
+	}
+
+	return g.Category, true
 }
 
 // PlatformByKey returns the game's platform with the provided key.

--- a/game/amiibo_festival.go
+++ b/game/amiibo_festival.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/gamecategory"
 	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
@@ -83,6 +84,7 @@ var (
 var (
 	// AmiiboFestival represents Animal Crossing: amiibo Festival.
 	AmiiboFestival = nook.Game{
+		Category:     gamecategory.Spinoff,
 		Key:          nook.Key(amiiboFestival),
 		Name:         amiiboFestivalName,
 		Platforms:    amiiboFestivalPlatforms,

--- a/game/animal_crossing.go
+++ b/game/animal_crossing.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/gamecategory"
 	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
@@ -74,6 +75,7 @@ var (
 var (
 	// AnimalCrossing represents Animal Crossing.
 	AnimalCrossing = nook.Game{
+		Category:     gamecategory.Mainline,
 		Key:          nook.Key(animalCrossing),
 		Name:         animalCrossingName,
 		Platforms:    animalCrossingPlatforms,

--- a/game/city_folk.go
+++ b/game/city_folk.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/gamecategory"
 	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
@@ -83,6 +84,7 @@ var (
 var (
 	// CityFolk represents Animal Crossing: City Folk.
 	CityFolk = nook.Game{
+		Category:     gamecategory.Mainline,
 		Key:          nook.Key(cityFolk),
 		Name:         cityFolkName,
 		Platforms:    cityFolkPlatforms,

--- a/game/dongwu_senlin.go
+++ b/game/dongwu_senlin.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/gamecategory"
 	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
@@ -56,6 +57,7 @@ var (
 var (
 	// DongwuSenlin represents Dongwu Senlin.
 	DongwuSenlin = nook.Game{
+		Category:     gamecategory.Mainline,
 		Key:          nook.Key(dongwuSenlin),
 		Name:         dongwuSenlinName,
 		Platforms:    dongwuSenlinPlatforms,

--- a/game/doubutsu_no_mori.go
+++ b/game/doubutsu_no_mori.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/gamecategory"
 	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
@@ -56,6 +57,7 @@ var (
 var (
 	// DoubutsuNoMori represents Doubutsu no Mori.
 	DoubutsuNoMori = nook.Game{
+		Category:     gamecategory.Mainline,
 		Key:          nook.Key(doubutsuNoMori),
 		Name:         doubutsuNoMoriName,
 		Platforms:    doubutsuNoMoriPlatforms,

--- a/game/doubutsu_no_mori_e_plus.go
+++ b/game/doubutsu_no_mori_e_plus.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/gamecategory"
 	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
@@ -56,6 +57,7 @@ var (
 var (
 	// DoubutsuNoMoriEPlus represents Doubutsu no Mori e+.
 	DoubutsuNoMoriEPlus = nook.Game{
+		Category:     gamecategory.Mainline,
 		Key:          nook.Key(doubutsuNoMoriEPlus),
 		Name:         doubutsuNoMoriEPlusName,
 		Platforms:    doubutsuNoMoriEPlusPlatforms,

--- a/game/doubutsu_no_mori_plus.go
+++ b/game/doubutsu_no_mori_plus.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/gamecategory"
 	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
@@ -56,6 +57,7 @@ var (
 var (
 	// DoubutsuNoMoriPlus represents Doubutsu no Mori+.
 	DoubutsuNoMoriPlus = nook.Game{
+		Category:     gamecategory.Mainline,
 		Key:          nook.Key(doubutsuNoMoriPlus),
 		Name:         doubutsuNoMoriPlusName,
 		Platforms:    doubutsuNoMoriPlusPlatforms,

--- a/game/happy_home_designer.go
+++ b/game/happy_home_designer.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/gamecategory"
 	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
@@ -83,6 +84,7 @@ var (
 var (
 	// HappyHomeDesigner represents Animal Crossing: Happy Home Designer.
 	HappyHomeDesigner = nook.Game{
+		Category:     gamecategory.Spinoff,
 		Key:          nook.Key(happyHomeDesigner),
 		Name:         happyHomeDesignerName,
 		Platforms:    happyHomeDesignerPlatforms,

--- a/game/new_horizons.go
+++ b/game/new_horizons.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/gamecategory"
 	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
@@ -56,6 +57,7 @@ var (
 var (
 	// NewHorizons represents Animal Crossing: New Horizons.
 	NewHorizons = nook.Game{
+		Category:     gamecategory.Mainline,
 		Key:          nook.Key(newHorizons),
 		Name:         newHorizonsName,
 		Platforms:    newHorizonsPlatforms,

--- a/game/new_leaf.go
+++ b/game/new_leaf.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/gamecategory"
 	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
@@ -83,6 +84,7 @@ var (
 var (
 	// NewLeaf represents Animal Crossing: New Leaf.
 	NewLeaf = nook.Game{
+		Category:     gamecategory.Mainline,
 		Key:          nook.Key(newLeaf),
 		Name:         newLeafName,
 		Platforms:    newLeafPlatforms,

--- a/game/pocket_camp.go
+++ b/game/pocket_camp.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/gamecategory"
 	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
@@ -66,6 +67,7 @@ var (
 var (
 	// PocketCamp represents Animal Crossing: Pocket Camp.
 	PocketCamp = nook.Game{
+		Category:     gamecategory.Mobile,
 		Key:          nook.Key(pocketCamp),
 		Name:         pocketCampName,
 		Platforms:    pocketCampPlatforms,

--- a/game/registry_test.go
+++ b/game/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/lindsaygelle/nook/game"
+	"github.com/lindsaygelle/nook/gamecategory"
 	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 )
@@ -24,6 +25,9 @@ func TestByKey(t *testing.T) {
 	}
 	if len(got.Platforms) != 1 {
 		t.Fatalf("len(game.ByKey(%s).Platforms) = %d", game.NewHorizons.Key, len(got.Platforms))
+	}
+	if got.Category.Key != gamecategory.Mainline.Key {
+		t.Fatalf("game.ByKey(%s).Category.Key = %s", game.NewHorizons.Key, got.Category.Key)
 	}
 }
 
@@ -130,5 +134,30 @@ func TestPlatformByKey(t *testing.T) {
 func TestPlatformByKeyMissing(t *testing.T) {
 	if _, ok := game.CityFolk.PlatformByKey(platform.NintendoSwitch.Key); ok {
 		t.Fatalf("game.CityFolk.PlatformByKey(%s) unexpectedly found a platform", platform.NintendoSwitch.Key)
+	}
+}
+
+func TestHasCategory(t *testing.T) {
+	if !game.NewHorizons.HasCategory(gamecategory.Mainline.Key) {
+		t.Fatalf("game.NewHorizons.HasCategory(%s) = false", gamecategory.Mainline.Key)
+	}
+	if game.NewHorizons.HasCategory(gamecategory.Spinoff.Key) {
+		t.Fatalf("game.NewHorizons.HasCategory(%s) = true", gamecategory.Spinoff.Key)
+	}
+}
+
+func TestCategoryByKey(t *testing.T) {
+	found, ok := game.PocketCamp.CategoryByKey(gamecategory.Mobile.Key)
+	if !ok {
+		t.Fatalf("game.PocketCamp.CategoryByKey(%s) not found", gamecategory.Mobile.Key)
+	}
+	if found.Key != gamecategory.Mobile.Key {
+		t.Fatalf("game.PocketCamp.CategoryByKey(%s).Key = %s", gamecategory.Mobile.Key, found.Key)
+	}
+}
+
+func TestCategoryByKeyMissing(t *testing.T) {
+	if _, ok := game.CityFolk.CategoryByKey(gamecategory.Mobile.Key); ok {
+		t.Fatalf("game.CityFolk.CategoryByKey(%s) unexpectedly found a category", gamecategory.Mobile.Key)
 	}
 }

--- a/game/wild_world.go
+++ b/game/wild_world.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lindsaygelle/nook"
+	"github.com/lindsaygelle/nook/gamecategory"
 	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 	"golang.org/x/text/language"
@@ -83,6 +84,7 @@ var (
 var (
 	// WildWorld represents Animal Crossing: Wild World.
 	WildWorld = nook.Game{
+		Category:     gamecategory.Mainline,
 		Key:          nook.Key(wildWorld),
 		Name:         wildWorldName,
 		Platforms:    wildWorldPlatforms,

--- a/game_category.go
+++ b/game_category.go
@@ -1,0 +1,10 @@
+package nook
+
+// GameCategory represents a series classification for an Animal Crossing game.
+type GameCategory struct {
+	// Key is the language-agnostic key of the game category.
+	Key Key
+
+	// Name contains the localized names of the game category.
+	Name Languages
+}

--- a/gamecategory/doc.go
+++ b/gamecategory/doc.go
@@ -1,0 +1,2 @@
+// Package gamecategory contains the canonical Animal Crossing game categories.
+package gamecategory

--- a/gamecategory/mainline.go
+++ b/gamecategory/mainline.go
@@ -1,0 +1,34 @@
+package gamecategory
+
+import (
+	"github.com/lindsaygelle/nook"
+	"golang.org/x/text/language"
+)
+
+const (
+	// mainline is the common reference for the Mainline game category.
+	mainline = "Mainline"
+)
+
+var (
+	// mainlineNameAmericanEnglish represents the Mainline game category's name in American English.
+	mainlineNameAmericanEnglish = nook.Name{
+		Language: language.AmericanEnglish,
+		Value:    "Mainline",
+	}
+)
+
+var (
+	// mainlineName contains the localized names of the Mainline game category.
+	mainlineName = nook.Languages{
+		language.AmericanEnglish: mainlineNameAmericanEnglish,
+	}
+)
+
+var (
+	// Mainline represents the Mainline game category in the Animal Crossing series.
+	Mainline = nook.GameCategory{
+		Key:  nook.Key(mainline),
+		Name: mainlineName,
+	}
+)

--- a/gamecategory/mobile.go
+++ b/gamecategory/mobile.go
@@ -1,0 +1,34 @@
+package gamecategory
+
+import (
+	"github.com/lindsaygelle/nook"
+	"golang.org/x/text/language"
+)
+
+const (
+	// mobile is the common reference for the Mobile game category.
+	mobile = "Mobile"
+)
+
+var (
+	// mobileNameAmericanEnglish represents the Mobile game category's name in American English.
+	mobileNameAmericanEnglish = nook.Name{
+		Language: language.AmericanEnglish,
+		Value:    "Mobile",
+	}
+)
+
+var (
+	// mobileName contains the localized names of the Mobile game category.
+	mobileName = nook.Languages{
+		language.AmericanEnglish: mobileNameAmericanEnglish,
+	}
+)
+
+var (
+	// Mobile represents the Mobile game category in the Animal Crossing series.
+	Mobile = nook.GameCategory{
+		Key:  nook.Key(mobile),
+		Name: mobileName,
+	}
+)

--- a/gamecategory/registry.go
+++ b/gamecategory/registry.go
@@ -1,0 +1,34 @@
+package gamecategory
+
+import "github.com/lindsaygelle/nook"
+
+var (
+	// categories contains the canonical game categories in deterministic key order.
+	categories = []nook.GameCategory{
+		Mainline,
+		Mobile,
+		Spinoff,
+	}
+)
+
+var (
+	// categoriesByKey contains canonical game categories indexed by key.
+	categoriesByKey = func() map[nook.Key]nook.GameCategory {
+		index := make(map[nook.Key]nook.GameCategory, len(categories))
+		for _, category := range categories {
+			index[category.Key] = category
+		}
+		return index
+	}()
+)
+
+// ByKey returns the canonical game category with the provided key.
+func ByKey(key nook.Key) (nook.GameCategory, bool) {
+	category, ok := categoriesByKey[key]
+	return category, ok
+}
+
+// List returns all canonical game categories in deterministic key order.
+func List() []nook.GameCategory {
+	return append([]nook.GameCategory(nil), categories...)
+}

--- a/gamecategory/registry_test.go
+++ b/gamecategory/registry_test.go
@@ -1,0 +1,46 @@
+package gamecategory_test
+
+import (
+	"testing"
+
+	"github.com/lindsaygelle/nook/gamecategory"
+)
+
+func TestByKey(t *testing.T) {
+	got, ok := gamecategory.ByKey(gamecategory.Mainline.Key)
+	if !ok {
+		t.Fatalf("gamecategory.ByKey(%s) not found", gamecategory.Mainline.Key)
+	}
+	if got.Key != gamecategory.Mainline.Key {
+		t.Fatalf("gamecategory.ByKey(%s).Key = %s", gamecategory.Mainline.Key, got.Key)
+	}
+}
+
+func TestByKeyMissing(t *testing.T) {
+	if _, ok := gamecategory.ByKey("missing"); ok {
+		t.Fatal("gamecategory.ByKey(missing) unexpectedly found a category")
+	}
+}
+
+func TestList(t *testing.T) {
+	categories := gamecategory.List()
+	if len(categories) != 3 {
+		t.Fatalf("len(gamecategory.List()) = %d", len(categories))
+	}
+	if categories[0].Key != gamecategory.Mainline.Key {
+		t.Fatalf("gamecategory.List()[0].Key = %s", categories[0].Key)
+	}
+	if categories[len(categories)-1].Key != gamecategory.Spinoff.Key {
+		t.Fatalf("gamecategory.List()[last].Key = %s", categories[len(categories)-1].Key)
+	}
+}
+
+func TestListReturnsCopy(t *testing.T) {
+	categories := gamecategory.List()
+	categories[0] = gamecategory.Spinoff
+
+	fresh := gamecategory.List()
+	if fresh[0].Key != gamecategory.Mainline.Key {
+		t.Fatalf("gamecategory.List()[0].Key after mutation = %s", fresh[0].Key)
+	}
+}

--- a/gamecategory/spinoff.go
+++ b/gamecategory/spinoff.go
@@ -1,0 +1,34 @@
+package gamecategory
+
+import (
+	"github.com/lindsaygelle/nook"
+	"golang.org/x/text/language"
+)
+
+const (
+	// spinoff is the common reference for the Spin-off game category.
+	spinoff = "Spinoff"
+)
+
+var (
+	// spinoffNameAmericanEnglish represents the Spin-off game category's name in American English.
+	spinoffNameAmericanEnglish = nook.Name{
+		Language: language.AmericanEnglish,
+		Value:    "Spin-off",
+	}
+)
+
+var (
+	// spinoffName contains the localized names of the Spin-off game category.
+	spinoffName = nook.Languages{
+		language.AmericanEnglish: spinoffNameAmericanEnglish,
+	}
+)
+
+var (
+	// Spinoff represents the Spin-off game category in the Animal Crossing series.
+	Spinoff = nook.GameCategory{
+		Key:  nook.Key(spinoff),
+		Name: spinoffName,
+	}
+)


### PR DESCRIPTION
### Description
Add canonical game category metadata owned directly by `nook.Game` and expose it through the record layer.

### Related Issue
N/A

### Changes Made
- added canonical `nook.GameCategory` plus a `gamecategory` registry package for mainline, spin-off, and mobile classifications
- extended `nook.Game` with owned `Category` data and model-level helpers for `HasCategory` and `CategoryByKey`
- populated each canonical game value with its category in the owning `game/*.go` files
- exposed `category` through `catalog.GameRecord`
- added test coverage for game category registries, game category helpers, and transport record serialization

### Screenshots (if applicable)
Not applicable.

### How to Test
1. Run `go test ./...`
2. Inspect `game/*.go` to confirm each canonical game owns its category data.
3. Inspect `gamecategory/` to verify the canonical category registry.
4. Inspect `catalog/record.go` and `catalog/record_test.go` to verify category metadata is exposed through `GameRecord`.

### Checklist
- [x] I have followed the coding style guidelines of the project.
- [x] My code passes all existing unit tests.
- [x] I have added new unit tests to cover the changes where applicable.
- [ ] I have updated the documentation to reflect the changes.
- [x] My changes do not introduce any new warnings or errors.
- [x] I have tested my changes thoroughly.

### Additional Notes
This keeps another useful piece of series structure on the canonical game values themselves, so downstream consumers do not need separate lookup tables to distinguish mainline releases from spin-offs or mobile entries.
