### PR TITLE
Add aggregate character game metadata

### DIFF
--- a/catalog/record.go
+++ b/catalog/record.go
@@ -38,6 +38,12 @@ type GameCategoryRecord struct {
 	Name LocalizedValues `json:"name"`
 }
 
+// RegionRecord is a transport-friendly game region representation.
+type RegionRecord struct {
+	Key  string          `json:"key"`
+	Name LocalizedValues `json:"name"`
+}
+
 // GameRecord is a transport-friendly game representation.
 type GameRecord struct {
 	Category     GameCategoryRecord  `json:"category"`
@@ -50,18 +56,21 @@ type GameRecord struct {
 
 // CharacterRecord is a flattened API-facing representation of a character.
 type CharacterRecord struct {
-	AnimalKey        string             `json:"animal_key"`
-	Birthday         BirthdayRecord     `json:"birthday"`
-	Code             string             `json:"code,omitempty"`
-	FirstReleaseDate *ReleaseDateRecord `json:"first_release_date,omitempty"`
-	Games            []GameRecord       `json:"games"`
-	Gender           LocalizedValues    `json:"gender"`
-	GenderKey        string             `json:"gender_key"`
-	ID               string             `json:"id"`
-	Key              string             `json:"key"`
-	LastReleaseDate  *ReleaseDateRecord `json:"last_release_date,omitempty"`
-	Name             LocalizedValues    `json:"name"`
-	Special          bool               `json:"special"`
+	AnimalKey        string               `json:"animal_key"`
+	Birthday         BirthdayRecord       `json:"birthday"`
+	Code             string               `json:"code,omitempty"`
+	FirstReleaseDate *ReleaseDateRecord   `json:"first_release_date,omitempty"`
+	GameCategories   []GameCategoryRecord `json:"game_categories"`
+	GamePlatforms    []PlatformRecord     `json:"game_platforms"`
+	GameRegions      []RegionRecord       `json:"game_regions"`
+	Games            []GameRecord         `json:"games"`
+	Gender           LocalizedValues      `json:"gender"`
+	GenderKey        string               `json:"gender_key"`
+	ID               string               `json:"id"`
+	Key              string               `json:"key"`
+	LastReleaseDate  *ReleaseDateRecord   `json:"last_release_date,omitempty"`
+	Name             LocalizedValues      `json:"name"`
+	Special          bool                 `json:"special"`
 }
 
 // ResidentRecord is an API-facing representation of a resident.
@@ -92,6 +101,14 @@ func gameCategoryRecordOf(category nook.GameCategory) GameCategoryRecord {
 	}
 }
 
+func gameCategoryRecordsOf(categories []nook.GameCategory) []GameCategoryRecord {
+	records := make([]GameCategoryRecord, 0, len(categories))
+	for _, category := range categories {
+		records = append(records, gameCategoryRecordOf(category))
+	}
+	return records
+}
+
 func platformRecordOf(platform nook.Platform) PlatformRecord {
 	return PlatformRecord{
 		Key:  string(platform.Key),
@@ -103,6 +120,21 @@ func platformRecordsOf(platforms []nook.Platform) []PlatformRecord {
 	records := make([]PlatformRecord, 0, len(platforms))
 	for _, platform := range platforms {
 		records = append(records, platformRecordOf(platform))
+	}
+	return records
+}
+
+func regionRecordOf(region nook.Region) RegionRecord {
+	return RegionRecord{
+		Key:  string(region.Key),
+		Name: LocalizedValuesOf(region.Name),
+	}
+}
+
+func regionRecordsOf(regions []nook.Region) []RegionRecord {
+	records := make([]RegionRecord, 0, len(regions))
+	for _, region := range regions {
+		records = append(records, regionRecordOf(region))
 	}
 	return records
 }
@@ -171,6 +203,9 @@ func CharacterRecordOf(character nook.Character) CharacterRecord {
 		},
 		Code:             character.Code.Value,
 		FirstReleaseDate: releaseDateRecordPointerOf(character.FirstReleaseDate()),
+		GameCategories:   gameCategoryRecordsOf(character.GameCategories()),
+		GamePlatforms:    platformRecordsOf(character.GamePlatforms()),
+		GameRegions:      regionRecordsOf(character.GameRegions()),
 		Games:            games,
 		Gender:           LocalizedValuesOf(character.Gender.Name),
 		GenderKey:        string(character.Gender.Key),

--- a/catalog/record_test.go
+++ b/catalog/record_test.go
@@ -89,6 +89,24 @@ func TestCharacterRecordOf(t *testing.T) {
 	if record.FirstReleaseDate.Year != 2001 || record.FirstReleaseDate.Month != 12 || record.FirstReleaseDate.Day != 14 {
 		t.Fatalf("catalog.CharacterRecordOf(cat.Ankha).FirstReleaseDate = %#v", record.FirstReleaseDate)
 	}
+	if len(record.GameCategories) != 3 {
+		t.Fatalf("len(catalog.CharacterRecordOf(cat.Ankha).GameCategories) = %d", len(record.GameCategories))
+	}
+	if record.GameCategories[0].Key != string(gamecategory.Mainline.Key) {
+		t.Fatalf("catalog.CharacterRecordOf(cat.Ankha).GameCategories[0].Key = %s", record.GameCategories[0].Key)
+	}
+	if len(record.GamePlatforms) != 7 {
+		t.Fatalf("len(catalog.CharacterRecordOf(cat.Ankha).GamePlatforms) = %d", len(record.GamePlatforms))
+	}
+	if record.GamePlatforms[0].Key != string(platform.Android.Key) {
+		t.Fatalf("catalog.CharacterRecordOf(cat.Ankha).GamePlatforms[0].Key = %s", record.GamePlatforms[0].Key)
+	}
+	if len(record.GameRegions) != 5 {
+		t.Fatalf("len(catalog.CharacterRecordOf(cat.Ankha).GameRegions) = %d", len(record.GameRegions))
+	}
+	if record.GameRegions[0].Key != string(region.Australia.Key) {
+		t.Fatalf("catalog.CharacterRecordOf(cat.Ankha).GameRegions[0].Key = %s", record.GameRegions[0].Key)
+	}
 	if len(record.Games) != 9 {
 		t.Fatalf("len(catalog.CharacterRecordOf(cat.Ankha).Games) = %d", len(record.Games))
 	}
@@ -111,6 +129,15 @@ func TestCharacterRecordOfWithoutReleaseDates(t *testing.T) {
 
 	if record.FirstReleaseDate != nil {
 		t.Fatalf("catalog.CharacterRecordOf(squirrel.Shaki).FirstReleaseDate = %#v", record.FirstReleaseDate)
+	}
+	if len(record.GameCategories) != 0 {
+		t.Fatalf("len(catalog.CharacterRecordOf(squirrel.Shaki).GameCategories) = %d", len(record.GameCategories))
+	}
+	if len(record.GamePlatforms) != 0 {
+		t.Fatalf("len(catalog.CharacterRecordOf(squirrel.Shaki).GamePlatforms) = %d", len(record.GamePlatforms))
+	}
+	if len(record.GameRegions) != 0 {
+		t.Fatalf("len(catalog.CharacterRecordOf(squirrel.Shaki).GameRegions) = %d", len(record.GameRegions))
 	}
 	if record.LastReleaseDate != nil {
 		t.Fatalf("catalog.CharacterRecordOf(squirrel.Shaki).LastReleaseDate = %#v", record.LastReleaseDate)

--- a/character.go
+++ b/character.go
@@ -4,6 +4,17 @@ import "slices"
 
 const characterIDSeparator = ":"
 
+func compareGameCategoriesByKey(a, b GameCategory) int {
+	switch {
+	case a.Key < b.Key:
+		return -1
+	case a.Key > b.Key:
+		return 1
+	default:
+		return 0
+	}
+}
+
 func compareGamesByReleaseOrder(a, b Game) int {
 	switch {
 	case a.ReleaseOrder == 0 && b.ReleaseOrder != 0:
@@ -16,6 +27,28 @@ func compareGamesByReleaseOrder(a, b Game) int {
 		return 1
 	}
 
+	switch {
+	case a.Key < b.Key:
+		return -1
+	case a.Key > b.Key:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func comparePlatformsByKey(a, b Platform) int {
+	switch {
+	case a.Key < b.Key:
+		return -1
+	case a.Key > b.Key:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func compareRegionsByKey(a, b Region) int {
 	switch {
 	case a.Key < b.Key:
 		return -1
@@ -100,6 +133,70 @@ func (c Character) GameByKey(gameKey Key) (Game, bool) {
 	}
 
 	return Game{}, false
+}
+
+// GameCategories returns the unique game categories represented across the
+// character's known game appearances in deterministic key order.
+func (c Character) GameCategories() []GameCategory {
+	index := make(map[Key]GameCategory, len(c.Games))
+
+	for _, game := range c.Games {
+		if game.Category.Key == "" {
+			continue
+		}
+		index[game.Category.Key] = game.Category
+	}
+
+	categories := make([]GameCategory, 0, len(index))
+	for _, category := range index {
+		categories = append(categories, category)
+	}
+	slices.SortFunc(categories, compareGameCategoriesByKey)
+	return categories
+}
+
+// GamePlatforms returns the unique platforms represented across the
+// character's known game appearances in deterministic key order.
+func (c Character) GamePlatforms() []Platform {
+	index := make(map[Key]Platform)
+
+	for _, game := range c.Games {
+		for _, platform := range game.Platforms {
+			if platform.Key == "" {
+				continue
+			}
+			index[platform.Key] = platform
+		}
+	}
+
+	platforms := make([]Platform, 0, len(index))
+	for _, platform := range index {
+		platforms = append(platforms, platform)
+	}
+	slices.SortFunc(platforms, comparePlatformsByKey)
+	return platforms
+}
+
+// GameRegions returns the unique release regions represented across the
+// character's known game appearances in deterministic key order.
+func (c Character) GameRegions() []Region {
+	index := make(map[Key]Region)
+
+	for _, game := range c.Games {
+		for _, releaseDate := range game.ReleaseDates {
+			if releaseDate.Region.Key == "" {
+				continue
+			}
+			index[releaseDate.Region.Key] = releaseDate.Region
+		}
+	}
+
+	regions := make([]Region, 0, len(index))
+	for _, region := range index {
+		regions = append(regions, region)
+	}
+	slices.SortFunc(regions, compareRegionsByKey)
+	return regions
 }
 
 // GamesOnPlatform returns a boolean indicating whether the character appears on

--- a/character_test.go
+++ b/character_test.go
@@ -9,6 +9,7 @@ import (
 	dogcharacters "github.com/lindsaygelle/nook/character/dog"
 	squirrelcharacters "github.com/lindsaygelle/nook/character/squirrel"
 	"github.com/lindsaygelle/nook/game"
+	"github.com/lindsaygelle/nook/gamecategory"
 	"github.com/lindsaygelle/nook/platform"
 	"github.com/lindsaygelle/nook/region"
 )
@@ -121,6 +122,36 @@ func TestCharacterGameByKey(t *testing.T) {
 	}
 }
 
+func TestCharacterGameCategories(t *testing.T) {
+	categories := dogcharacters.Isabelle.Character.GameCategories()
+	if len(categories) != 3 {
+		t.Fatalf("len(%s.GameCategories()) = %d", dogcharacters.Isabelle.Key, len(categories))
+	}
+	if categories[0].Key != gamecategory.Mainline.Key {
+		t.Fatalf("%s.GameCategories()[0].Key = %s", dogcharacters.Isabelle.Key, categories[0].Key)
+	}
+	if categories[1].Key != gamecategory.Mobile.Key {
+		t.Fatalf("%s.GameCategories()[1].Key = %s", dogcharacters.Isabelle.Key, categories[1].Key)
+	}
+	if categories[2].Key != gamecategory.Spinoff.Key {
+		t.Fatalf("%s.GameCategories()[2].Key = %s", dogcharacters.Isabelle.Key, categories[2].Key)
+	}
+
+	categories = catcharacters.Ankha.Character.GameCategories()
+	if len(categories) != 3 {
+		t.Fatalf("len(%s.GameCategories()) = %d", catcharacters.Ankha.Key, len(categories))
+	}
+	if categories[0].Key != gamecategory.Mainline.Key {
+		t.Fatalf("%s.GameCategories()[0].Key = %s", catcharacters.Ankha.Key, categories[0].Key)
+	}
+	if categories[1].Key != gamecategory.Mobile.Key {
+		t.Fatalf("%s.GameCategories()[1].Key = %s", catcharacters.Ankha.Key, categories[1].Key)
+	}
+	if categories[2].Key != gamecategory.Spinoff.Key {
+		t.Fatalf("%s.GameCategories()[2].Key = %s", catcharacters.Ankha.Key, categories[2].Key)
+	}
+}
+
 func TestCharacterGamesByReleaseOrder(t *testing.T) {
 	games := catcharacters.Ankha.Character.GamesByReleaseOrder()
 	if len(games) != len(catcharacters.Ankha.Character.Games) {
@@ -141,12 +172,38 @@ func TestCharacterGamesByReleaseOrder(t *testing.T) {
 	}
 }
 
+func TestCharacterGamePlatforms(t *testing.T) {
+	platforms := dogcharacters.Isabelle.Character.GamePlatforms()
+	if len(platforms) != 5 {
+		t.Fatalf("len(%s.GamePlatforms()) = %d", dogcharacters.Isabelle.Key, len(platforms))
+	}
+	if platforms[0].Key != platform.Android.Key {
+		t.Fatalf("%s.GamePlatforms()[0].Key = %s", dogcharacters.Isabelle.Key, platforms[0].Key)
+	}
+	if platforms[len(platforms)-1].Key != platform.WiiU.Key {
+		t.Fatalf("%s.GamePlatforms()[last].Key = %s", dogcharacters.Isabelle.Key, platforms[len(platforms)-1].Key)
+	}
+}
+
 func TestCharacterGamesOnPlatform(t *testing.T) {
 	if !dogcharacters.Isabelle.Character.GamesOnPlatform(platform.Nintendo3DS.Key) {
 		t.Fatalf("%s.GamesOnPlatform(%s) = false", dogcharacters.Isabelle.Key, platform.Nintendo3DS.Key)
 	}
 	if dogcharacters.Isabelle.Character.GamesOnPlatform(platform.Nintendo64.Key) {
 		t.Fatalf("%s.GamesOnPlatform(%s) = true", dogcharacters.Isabelle.Key, platform.Nintendo64.Key)
+	}
+}
+
+func TestCharacterGameRegions(t *testing.T) {
+	regions := dogcharacters.Isabelle.Character.GameRegions()
+	if len(regions) != 5 {
+		t.Fatalf("len(%s.GameRegions()) = %d", dogcharacters.Isabelle.Key, len(regions))
+	}
+	if regions[0].Key != region.Australia.Key {
+		t.Fatalf("%s.GameRegions()[0].Key = %s", dogcharacters.Isabelle.Key, regions[0].Key)
+	}
+	if regions[len(regions)-1].Key != region.Worldwide.Key {
+		t.Fatalf("%s.GameRegions()[last].Key = %s", dogcharacters.Isabelle.Key, regions[len(regions)-1].Key)
 	}
 }
 
@@ -168,6 +225,15 @@ func TestCharacterGamesWithoutKnownAppearances(t *testing.T) {
 	}
 	if _, ok := squirrelcharacters.Shaki.Character.FirstReleaseDate(); ok {
 		t.Fatalf("%s.FirstReleaseDate() unexpectedly found a release date", squirrelcharacters.Shaki.Key)
+	}
+	if len(squirrelcharacters.Shaki.Character.GameCategories()) != 0 {
+		t.Fatalf("len(%s.GameCategories()) = %d", squirrelcharacters.Shaki.Key, len(squirrelcharacters.Shaki.Character.GameCategories()))
+	}
+	if len(squirrelcharacters.Shaki.Character.GamePlatforms()) != 0 {
+		t.Fatalf("len(%s.GamePlatforms()) = %d", squirrelcharacters.Shaki.Key, len(squirrelcharacters.Shaki.Character.GamePlatforms()))
+	}
+	if len(squirrelcharacters.Shaki.Character.GameRegions()) != 0 {
+		t.Fatalf("len(%s.GameRegions()) = %d", squirrelcharacters.Shaki.Key, len(squirrelcharacters.Shaki.Character.GameRegions()))
 	}
 	if _, ok := squirrelcharacters.Shaki.Character.LastReleaseDate(); ok {
 		t.Fatalf("%s.LastReleaseDate() unexpectedly found a release date", squirrelcharacters.Shaki.Key)


### PR DESCRIPTION
### Description
Add aggregate character game metadata so downstream consumers can access a character's overall game categories, platforms, and regions without re-walking each game appearance.

### Related Issue
N/A

### Changes Made
- added deterministic `nook.Character` helpers for `GameCategories`, `GamePlatforms`, and `GameRegions`
- kept the aggregate logic on the root character model so it is available outside the catalog layer
- extended `catalog.CharacterRecord` with `game_categories`, `game_platforms`, and `game_regions`
- added tests covering the new character aggregate helpers and their record serialization

### Screenshots (if applicable)
Not applicable.

### How to Test
1. Run `go test ./...`
2. Inspect `character.go` to verify aggregate category/platform/region helpers live on `nook.Character`.
3. Inspect `catalog/record.go` and `catalog/record_test.go` to confirm the aggregate metadata is exposed through `CharacterRecord`.

### Checklist
- [x] I have followed the coding style guidelines of the project.
- [x] My code passes all existing unit tests.
- [x] I have added new unit tests to cover the changes where applicable.
- [ ] I have updated the documentation to reflect the changes.
- [x] My changes do not introduce any new warnings or errors.
- [x] I have tested my changes thoroughly.

### Additional Notes
This keeps the distilled series footprint of each character directly available from canonical Go model values, which is useful for CLI and service consumers that do not want to derive aggregate game metadata themselves.
