### PR TITLE
Add category-based character game filters

### DIFF
--- a/catalog/game.go
+++ b/catalog/game.go
@@ -83,6 +83,28 @@ func ResidentsByGame(gameKey nook.Key) []nook.Resident {
 	return residents
 }
 
+// ResidentsByGameCategory returns all residents that appear in at least one
+// game within the provided category. Results are sorted by animal key and then
+// character key for deterministic backend responses.
+func ResidentsByGameCategory(categoryKey nook.Key) []nook.Resident {
+	if categoryKey == "" {
+		return nil
+	}
+
+	residents := make([]nook.Resident, 0)
+	for _, bucket := range AllResidents {
+		for _, resident := range bucket {
+			if len(resident.Character.GamesByCategory(categoryKey)) == 0 {
+				continue
+			}
+			residents = append(residents, resident)
+		}
+	}
+
+	slices.SortFunc(residents, compareResidents)
+	return residents
+}
+
 // VillagersByGame returns all villagers that appear in the provided game.
 // Results are sorted by animal key and then character key for deterministic
 // backend responses.
@@ -95,6 +117,28 @@ func VillagersByGame(gameKey nook.Key) []nook.Villager {
 	for _, bucket := range AllVillagers {
 		for _, villager := range bucket {
 			if !villager.Character.AppearsInGame(gameKey) {
+				continue
+			}
+			villagers = append(villagers, villager)
+		}
+	}
+
+	slices.SortFunc(villagers, compareVillagers)
+	return villagers
+}
+
+// VillagersByGameCategory returns all villagers that appear in at least one
+// game within the provided category. Results are sorted by animal key and then
+// character key for deterministic backend responses.
+func VillagersByGameCategory(categoryKey nook.Key) []nook.Villager {
+	if categoryKey == "" {
+		return nil
+	}
+
+	villagers := make([]nook.Villager, 0)
+	for _, bucket := range AllVillagers {
+		for _, villager := range bucket {
+			if len(villager.Character.GamesByCategory(categoryKey)) == 0 {
 				continue
 			}
 			villagers = append(villagers, villager)

--- a/catalog/game_test.go
+++ b/catalog/game_test.go
@@ -11,6 +11,7 @@ import (
 	dogcharacters "github.com/lindsaygelle/nook/character/dog"
 	squirrelcharacters "github.com/lindsaygelle/nook/character/squirrel"
 	"github.com/lindsaygelle/nook/game"
+	"github.com/lindsaygelle/nook/gamecategory"
 )
 
 func TestCharacterGamesByID(t *testing.T) {
@@ -197,6 +198,44 @@ func TestResidentsByGameEmptyKey(t *testing.T) {
 	}
 }
 
+func TestResidentsByGameCategory(t *testing.T) {
+	residents := catalog.ResidentsByGameCategory(gamecategory.Mainline.Key)
+	if len(residents) == 0 {
+		t.Fatal("catalog.ResidentsByGameCategory(Mainline) returned no residents")
+	}
+
+	foundIsabelle := false
+	for i, resident := range residents {
+		if len(resident.Character.GamesByCategory(gamecategory.Mainline.Key)) == 0 {
+			t.Fatalf("catalog.ResidentsByGameCategory(Mainline)[%d] missing mainline appearance", i)
+		}
+		if resident.Character.Animal.Key == animal.Dog.Key && resident.Character.Key == character.Isabelle {
+			foundIsabelle = true
+		}
+		if i == 0 {
+			continue
+		}
+
+		prev := residents[i-1]
+		if resident.Character.Animal.Key < prev.Character.Animal.Key {
+			t.Fatalf("catalog.ResidentsByGameCategory(Mainline)[%d] not sorted by animal key", i)
+		}
+		if resident.Character.Animal.Key == prev.Character.Animal.Key && resident.Character.Key < prev.Character.Key {
+			t.Fatalf("catalog.ResidentsByGameCategory(Mainline)[%d] not sorted by character key", i)
+		}
+	}
+	if !foundIsabelle {
+		t.Fatal("catalog.ResidentsByGameCategory(Mainline) missing Isabelle")
+	}
+}
+
+func TestResidentsByGameCategoryEmptyKey(t *testing.T) {
+	residents := catalog.ResidentsByGameCategory("")
+	if residents != nil {
+		t.Fatalf("catalog.ResidentsByGameCategory(\"\") = %#v", residents)
+	}
+}
+
 func TestVillagersByGame(t *testing.T) {
 	villagers := catalog.VillagersByGame(game.DoubutsuNoMoriPlus.Key)
 	if len(villagers) == 0 {
@@ -232,6 +271,44 @@ func TestVillagersByGameEmptyKey(t *testing.T) {
 	villagers := catalog.VillagersByGame("")
 	if villagers != nil {
 		t.Fatalf("catalog.VillagersByGame(\"\") = %#v", villagers)
+	}
+}
+
+func TestVillagersByGameCategory(t *testing.T) {
+	villagers := catalog.VillagersByGameCategory(gamecategory.Spinoff.Key)
+	if len(villagers) == 0 {
+		t.Fatal("catalog.VillagersByGameCategory(Spinoff) returned no villagers")
+	}
+
+	foundAnkha := false
+	for i, villager := range villagers {
+		if len(villager.Character.GamesByCategory(gamecategory.Spinoff.Key)) == 0 {
+			t.Fatalf("catalog.VillagersByGameCategory(Spinoff)[%d] missing spinoff appearance", i)
+		}
+		if villager.Character.Animal.Key == animal.Cat.Key && villager.Character.Key == character.Ankha {
+			foundAnkha = true
+		}
+		if i == 0 {
+			continue
+		}
+
+		prev := villagers[i-1]
+		if villager.Character.Animal.Key < prev.Character.Animal.Key {
+			t.Fatalf("catalog.VillagersByGameCategory(Spinoff)[%d] not sorted by animal key", i)
+		}
+		if villager.Character.Animal.Key == prev.Character.Animal.Key && villager.Character.Key < prev.Character.Key {
+			t.Fatalf("catalog.VillagersByGameCategory(Spinoff)[%d] not sorted by character key", i)
+		}
+	}
+	if !foundAnkha {
+		t.Fatal("catalog.VillagersByGameCategory(Spinoff) missing Ankha")
+	}
+}
+
+func TestVillagersByGameCategoryEmptyKey(t *testing.T) {
+	villagers := catalog.VillagersByGameCategory("")
+	if villagers != nil {
+		t.Fatalf("catalog.VillagersByGameCategory(\"\") = %#v", villagers)
 	}
 }
 

--- a/catalog/record.go
+++ b/catalog/record.go
@@ -294,6 +294,18 @@ func ResidentRecordsByGame(gameKey nook.Key) []ResidentRecord {
 	return records
 }
 
+// ResidentRecordsByGameCategory returns all residents that appear in at least
+// one game within the provided category. Results are ordered by animal key and
+// then character key.
+func ResidentRecordsByGameCategory(categoryKey nook.Key) []ResidentRecord {
+	residents := ResidentsByGameCategory(categoryKey)
+	records := make([]ResidentRecord, 0, len(residents))
+	for _, resident := range residents {
+		records = append(records, ResidentRecordOf(resident))
+	}
+	return records
+}
+
 // ResidentRecordsByGender returns all residents whose gender exactly matches
 // the provided gender key. Results are ordered by animal key and then
 // character key.
@@ -380,6 +392,18 @@ func VillagerRecordsByBirthMonth(month time.Month) []VillagerRecord {
 // game. Results are ordered by animal key and then character key.
 func VillagerRecordsByGame(gameKey nook.Key) []VillagerRecord {
 	villagers := VillagersByGame(gameKey)
+	records := make([]VillagerRecord, 0, len(villagers))
+	for _, villager := range villagers {
+		records = append(records, VillagerRecordOf(villager))
+	}
+	return records
+}
+
+// VillagerRecordsByGameCategory returns all villagers that appear in at least
+// one game within the provided category. Results are ordered by animal key and
+// then character key.
+func VillagerRecordsByGameCategory(categoryKey nook.Key) []VillagerRecord {
+	villagers := VillagersByGameCategory(categoryKey)
 	records := make([]VillagerRecord, 0, len(villagers))
 	for _, villager := range villagers {
 		records = append(records, VillagerRecordOf(villager))

--- a/catalog/record_test.go
+++ b/catalog/record_test.go
@@ -277,6 +277,34 @@ func TestResidentRecordsByGame(t *testing.T) {
 	}
 }
 
+func TestResidentRecordsByGameCategory(t *testing.T) {
+	records := catalog.ResidentRecordsByGameCategory(gamecategory.Mainline.Key)
+	if len(records) == 0 {
+		t.Fatal("catalog.ResidentRecordsByGameCategory(Mainline) returned no records")
+	}
+
+	foundIsabelle := false
+	for i, record := range records {
+		if record.ID == "Dog:Isabelle" {
+			foundIsabelle = true
+		}
+		if i == 0 {
+			continue
+		}
+
+		prev := records[i-1]
+		if record.AnimalKey < prev.AnimalKey {
+			t.Fatalf("catalog.ResidentRecordsByGameCategory(Mainline)[%d] not sorted by animal key", i)
+		}
+		if record.AnimalKey == prev.AnimalKey && record.Key < prev.Key {
+			t.Fatalf("catalog.ResidentRecordsByGameCategory(Mainline)[%d] not sorted by character key", i)
+		}
+	}
+	if !foundIsabelle {
+		t.Fatal("catalog.ResidentRecordsByGameCategory(Mainline) missing Isabelle")
+	}
+}
+
 func TestResidentRecordsByGender(t *testing.T) {
 	records := catalog.ResidentRecordsByGender(gender.Female.Key)
 	if len(records) == 0 {
@@ -453,6 +481,34 @@ func TestVillagerRecordsByGame(t *testing.T) {
 	}
 }
 
+func TestVillagerRecordsByGameCategory(t *testing.T) {
+	records := catalog.VillagerRecordsByGameCategory(gamecategory.Spinoff.Key)
+	if len(records) == 0 {
+		t.Fatal("catalog.VillagerRecordsByGameCategory(Spinoff) returned no records")
+	}
+
+	foundAnkha := false
+	for i, record := range records {
+		if record.ID == "Cat:Ankha" {
+			foundAnkha = true
+		}
+		if i == 0 {
+			continue
+		}
+
+		prev := records[i-1]
+		if record.AnimalKey < prev.AnimalKey {
+			t.Fatalf("catalog.VillagerRecordsByGameCategory(Spinoff)[%d] not sorted by animal key", i)
+		}
+		if record.AnimalKey == prev.AnimalKey && record.Key < prev.Key {
+			t.Fatalf("catalog.VillagerRecordsByGameCategory(Spinoff)[%d] not sorted by character key", i)
+		}
+	}
+	if !foundAnkha {
+		t.Fatal("catalog.VillagerRecordsByGameCategory(Spinoff) missing Ankha")
+	}
+}
+
 func TestVillagerRecordsByGender(t *testing.T) {
 	records := catalog.VillagerRecordsByGender(gender.Male.Key)
 	if len(records) == 0 {
@@ -515,6 +571,9 @@ func TestRecordHelpersMissingAnimalBucket(t *testing.T) {
 	if records := catalog.ResidentRecordsByGame(""); len(records) != 0 {
 		t.Fatalf("len(catalog.ResidentRecordsByGame(\"\")) = %d", len(records))
 	}
+	if records := catalog.ResidentRecordsByGameCategory(""); len(records) != 0 {
+		t.Fatalf("len(catalog.ResidentRecordsByGameCategory(\"\")) = %d", len(records))
+	}
 	if records := catalog.ResidentRecordsByGender(""); len(records) != 0 {
 		t.Fatalf("len(catalog.ResidentRecordsByGender(\"\")) = %d", len(records))
 	}
@@ -523,6 +582,9 @@ func TestRecordHelpersMissingAnimalBucket(t *testing.T) {
 	}
 	if records := catalog.VillagerRecordsByGame(""); len(records) != 0 {
 		t.Fatalf("len(catalog.VillagerRecordsByGame(\"\")) = %d", len(records))
+	}
+	if records := catalog.VillagerRecordsByGameCategory(""); len(records) != 0 {
+		t.Fatalf("len(catalog.VillagerRecordsByGameCategory(\"\")) = %d", len(records))
 	}
 	if records := catalog.VillagerRecordsByGender(""); len(records) != 0 {
 		t.Fatalf("len(catalog.VillagerRecordsByGender(\"\")) = %d", len(records))

--- a/character.go
+++ b/character.go
@@ -135,6 +135,24 @@ func (c Character) GameByKey(gameKey Key) (Game, bool) {
 	return Game{}, false
 }
 
+// GamesByCategory returns the character's game appearances within the provided
+// category sorted into deterministic release order.
+func (c Character) GamesByCategory(categoryKey Key) []Game {
+	if categoryKey == "" {
+		return nil
+	}
+
+	games := make([]Game, 0)
+	for _, game := range c.GamesByReleaseOrder() {
+		if !game.HasCategory(categoryKey) {
+			continue
+		}
+		games = append(games, game)
+	}
+
+	return games
+}
+
 // GameCategories returns the unique game categories represented across the
 // character's known game appearances in deterministic key order.
 func (c Character) GameCategories() []GameCategory {

--- a/character_test.go
+++ b/character_test.go
@@ -122,6 +122,27 @@ func TestCharacterGameByKey(t *testing.T) {
 	}
 }
 
+func TestCharacterGamesByCategory(t *testing.T) {
+	games := catcharacters.Ankha.Character.GamesByCategory(gamecategory.Mainline.Key)
+	if len(games) != 6 {
+		t.Fatalf("len(%s.GamesByCategory(%s)) = %d", catcharacters.Ankha.Key, gamecategory.Mainline.Key, len(games))
+	}
+	if games[0].Key != game.DoubutsuNoMoriPlus.Key {
+		t.Fatalf("%s.GamesByCategory(%s)[0].Key = %s", catcharacters.Ankha.Key, gamecategory.Mainline.Key, games[0].Key)
+	}
+	if games[len(games)-1].Key != game.NewHorizons.Key {
+		t.Fatalf("%s.GamesByCategory(%s)[last].Key = %s", catcharacters.Ankha.Key, gamecategory.Mainline.Key, games[len(games)-1].Key)
+	}
+
+	games = catcharacters.Ankha.Character.GamesByCategory(gamecategory.Mobile.Key)
+	if len(games) != 1 {
+		t.Fatalf("len(%s.GamesByCategory(%s)) = %d", catcharacters.Ankha.Key, gamecategory.Mobile.Key, len(games))
+	}
+	if games[0].Key != game.PocketCamp.Key {
+		t.Fatalf("%s.GamesByCategory(%s)[0].Key = %s", catcharacters.Ankha.Key, gamecategory.Mobile.Key, games[0].Key)
+	}
+}
+
 func TestCharacterGameCategories(t *testing.T) {
 	categories := dogcharacters.Isabelle.Character.GameCategories()
 	if len(categories) != 3 {
@@ -228,6 +249,9 @@ func TestCharacterGamesWithoutKnownAppearances(t *testing.T) {
 	}
 	if len(squirrelcharacters.Shaki.Character.GameCategories()) != 0 {
 		t.Fatalf("len(%s.GameCategories()) = %d", squirrelcharacters.Shaki.Key, len(squirrelcharacters.Shaki.Character.GameCategories()))
+	}
+	if len(squirrelcharacters.Shaki.Character.GamesByCategory(gamecategory.Mainline.Key)) != 0 {
+		t.Fatalf("len(%s.GamesByCategory(%s)) = %d", squirrelcharacters.Shaki.Key, gamecategory.Mainline.Key, len(squirrelcharacters.Shaki.Character.GamesByCategory(gamecategory.Mainline.Key)))
 	}
 	if len(squirrelcharacters.Shaki.Character.GamePlatforms()) != 0 {
 		t.Fatalf("len(%s.GamePlatforms()) = %d", squirrelcharacters.Shaki.Key, len(squirrelcharacters.Shaki.Character.GamePlatforms()))


### PR DESCRIPTION
### Description
Add category-based character game helpers and catalog filters built on top of the owned game category model.

### Related Issue
N/A

### Changes Made
- added `nook.Character.GamesByCategory` for deterministic category-scoped game history on the root model
- added `catalog.ResidentsByGameCategory` and `catalog.VillagersByGameCategory`
- added `catalog.ResidentRecordsByGameCategory` and `catalog.VillagerRecordsByGameCategory`
- added tests covering the new model helper, sorted catalog results, and record serialization behavior for category-scoped queries

### Screenshots (if applicable)
Not applicable.

### How to Test
1. Run `go test ./...`
2. Inspect `character.go` to verify `GamesByCategory` lives on `nook.Character`.
3. Inspect `catalog/game.go` and `catalog/record.go` to confirm category-based resident and villager filters delegate to the model data.

### Checklist
- [x] I have followed the coding style guidelines of the project.
- [x] My code passes all existing unit tests.
- [x] I have added new unit tests to cover the changes where applicable.
- [ ] I have updated the documentation to reflect the changes.
- [x] My changes do not introduce any new warnings or errors.
- [x] I have tested my changes thoroughly.

### Additional Notes
This uses the already-owned `GameCategory` facts to make category-scoped filtering available without introducing any separate lookup table or duplicating series classification logic in downstream consumers.
