### PR TITLE
Add platform-based character game filters

### DIFF
--- a/catalog/game.go
+++ b/catalog/game.go
@@ -105,6 +105,28 @@ func ResidentsByGameCategory(categoryKey nook.Key) []nook.Resident {
 	return residents
 }
 
+// ResidentsByGamePlatform returns all residents that appear in at least one
+// game on the provided platform. Results are sorted by animal key and then
+// character key for deterministic backend responses.
+func ResidentsByGamePlatform(platformKey nook.Key) []nook.Resident {
+	if platformKey == "" {
+		return nil
+	}
+
+	residents := make([]nook.Resident, 0)
+	for _, bucket := range AllResidents {
+		for _, resident := range bucket {
+			if len(resident.Character.GamesByPlatform(platformKey)) == 0 {
+				continue
+			}
+			residents = append(residents, resident)
+		}
+	}
+
+	slices.SortFunc(residents, compareResidents)
+	return residents
+}
+
 // VillagersByGame returns all villagers that appear in the provided game.
 // Results are sorted by animal key and then character key for deterministic
 // backend responses.
@@ -117,6 +139,28 @@ func VillagersByGame(gameKey nook.Key) []nook.Villager {
 	for _, bucket := range AllVillagers {
 		for _, villager := range bucket {
 			if !villager.Character.AppearsInGame(gameKey) {
+				continue
+			}
+			villagers = append(villagers, villager)
+		}
+	}
+
+	slices.SortFunc(villagers, compareVillagers)
+	return villagers
+}
+
+// VillagersByGamePlatform returns all villagers that appear in at least one
+// game on the provided platform. Results are sorted by animal key and then
+// character key for deterministic backend responses.
+func VillagersByGamePlatform(platformKey nook.Key) []nook.Villager {
+	if platformKey == "" {
+		return nil
+	}
+
+	villagers := make([]nook.Villager, 0)
+	for _, bucket := range AllVillagers {
+		for _, villager := range bucket {
+			if len(villager.Character.GamesByPlatform(platformKey)) == 0 {
 				continue
 			}
 			villagers = append(villagers, villager)

--- a/catalog/game_test.go
+++ b/catalog/game_test.go
@@ -12,6 +12,7 @@ import (
 	squirrelcharacters "github.com/lindsaygelle/nook/character/squirrel"
 	"github.com/lindsaygelle/nook/game"
 	"github.com/lindsaygelle/nook/gamecategory"
+	"github.com/lindsaygelle/nook/platform"
 )
 
 func TestCharacterGamesByID(t *testing.T) {
@@ -236,6 +237,44 @@ func TestResidentsByGameCategoryEmptyKey(t *testing.T) {
 	}
 }
 
+func TestResidentsByGamePlatform(t *testing.T) {
+	residents := catalog.ResidentsByGamePlatform(platform.NintendoSwitch.Key)
+	if len(residents) == 0 {
+		t.Fatal("catalog.ResidentsByGamePlatform(NintendoSwitch) returned no residents")
+	}
+
+	foundIsabelle := false
+	for i, resident := range residents {
+		if len(resident.Character.GamesByPlatform(platform.NintendoSwitch.Key)) == 0 {
+			t.Fatalf("catalog.ResidentsByGamePlatform(NintendoSwitch)[%d] missing Nintendo Switch appearance", i)
+		}
+		if resident.Character.Animal.Key == animal.Dog.Key && resident.Character.Key == character.Isabelle {
+			foundIsabelle = true
+		}
+		if i == 0 {
+			continue
+		}
+
+		prev := residents[i-1]
+		if resident.Character.Animal.Key < prev.Character.Animal.Key {
+			t.Fatalf("catalog.ResidentsByGamePlatform(NintendoSwitch)[%d] not sorted by animal key", i)
+		}
+		if resident.Character.Animal.Key == prev.Character.Animal.Key && resident.Character.Key < prev.Character.Key {
+			t.Fatalf("catalog.ResidentsByGamePlatform(NintendoSwitch)[%d] not sorted by character key", i)
+		}
+	}
+	if !foundIsabelle {
+		t.Fatal("catalog.ResidentsByGamePlatform(NintendoSwitch) missing Isabelle")
+	}
+}
+
+func TestResidentsByGamePlatformEmptyKey(t *testing.T) {
+	residents := catalog.ResidentsByGamePlatform("")
+	if residents != nil {
+		t.Fatalf("catalog.ResidentsByGamePlatform(\"\") = %#v", residents)
+	}
+}
+
 func TestVillagersByGame(t *testing.T) {
 	villagers := catalog.VillagersByGame(game.DoubutsuNoMoriPlus.Key)
 	if len(villagers) == 0 {
@@ -309,6 +348,44 @@ func TestVillagersByGameCategoryEmptyKey(t *testing.T) {
 	villagers := catalog.VillagersByGameCategory("")
 	if villagers != nil {
 		t.Fatalf("catalog.VillagersByGameCategory(\"\") = %#v", villagers)
+	}
+}
+
+func TestVillagersByGamePlatform(t *testing.T) {
+	villagers := catalog.VillagersByGamePlatform(platform.Android.Key)
+	if len(villagers) == 0 {
+		t.Fatal("catalog.VillagersByGamePlatform(Android) returned no villagers")
+	}
+
+	foundAnkha := false
+	for i, villager := range villagers {
+		if len(villager.Character.GamesByPlatform(platform.Android.Key)) == 0 {
+			t.Fatalf("catalog.VillagersByGamePlatform(Android)[%d] missing Android appearance", i)
+		}
+		if villager.Character.Animal.Key == animal.Cat.Key && villager.Character.Key == character.Ankha {
+			foundAnkha = true
+		}
+		if i == 0 {
+			continue
+		}
+
+		prev := villagers[i-1]
+		if villager.Character.Animal.Key < prev.Character.Animal.Key {
+			t.Fatalf("catalog.VillagersByGamePlatform(Android)[%d] not sorted by animal key", i)
+		}
+		if villager.Character.Animal.Key == prev.Character.Animal.Key && villager.Character.Key < prev.Character.Key {
+			t.Fatalf("catalog.VillagersByGamePlatform(Android)[%d] not sorted by character key", i)
+		}
+	}
+	if !foundAnkha {
+		t.Fatal("catalog.VillagersByGamePlatform(Android) missing Ankha")
+	}
+}
+
+func TestVillagersByGamePlatformEmptyKey(t *testing.T) {
+	villagers := catalog.VillagersByGamePlatform("")
+	if villagers != nil {
+		t.Fatalf("catalog.VillagersByGamePlatform(\"\") = %#v", villagers)
 	}
 }
 

--- a/catalog/record.go
+++ b/catalog/record.go
@@ -306,6 +306,18 @@ func ResidentRecordsByGameCategory(categoryKey nook.Key) []ResidentRecord {
 	return records
 }
 
+// ResidentRecordsByGamePlatform returns all residents that appear in at least
+// one game on the provided platform. Results are ordered by animal key and
+// then character key.
+func ResidentRecordsByGamePlatform(platformKey nook.Key) []ResidentRecord {
+	residents := ResidentsByGamePlatform(platformKey)
+	records := make([]ResidentRecord, 0, len(residents))
+	for _, resident := range residents {
+		records = append(records, ResidentRecordOf(resident))
+	}
+	return records
+}
+
 // ResidentRecordsByGender returns all residents whose gender exactly matches
 // the provided gender key. Results are ordered by animal key and then
 // character key.
@@ -404,6 +416,18 @@ func VillagerRecordsByGame(gameKey nook.Key) []VillagerRecord {
 // then character key.
 func VillagerRecordsByGameCategory(categoryKey nook.Key) []VillagerRecord {
 	villagers := VillagersByGameCategory(categoryKey)
+	records := make([]VillagerRecord, 0, len(villagers))
+	for _, villager := range villagers {
+		records = append(records, VillagerRecordOf(villager))
+	}
+	return records
+}
+
+// VillagerRecordsByGamePlatform returns all villagers that appear in at least
+// one game on the provided platform. Results are ordered by animal key and
+// then character key.
+func VillagerRecordsByGamePlatform(platformKey nook.Key) []VillagerRecord {
+	villagers := VillagersByGamePlatform(platformKey)
 	records := make([]VillagerRecord, 0, len(villagers))
 	for _, villager := range villagers {
 		records = append(records, VillagerRecordOf(villager))

--- a/catalog/record_test.go
+++ b/catalog/record_test.go
@@ -305,6 +305,34 @@ func TestResidentRecordsByGameCategory(t *testing.T) {
 	}
 }
 
+func TestResidentRecordsByGamePlatform(t *testing.T) {
+	records := catalog.ResidentRecordsByGamePlatform(platform.NintendoSwitch.Key)
+	if len(records) == 0 {
+		t.Fatal("catalog.ResidentRecordsByGamePlatform(NintendoSwitch) returned no records")
+	}
+
+	foundIsabelle := false
+	for i, record := range records {
+		if record.ID == "Dog:Isabelle" {
+			foundIsabelle = true
+		}
+		if i == 0 {
+			continue
+		}
+
+		prev := records[i-1]
+		if record.AnimalKey < prev.AnimalKey {
+			t.Fatalf("catalog.ResidentRecordsByGamePlatform(NintendoSwitch)[%d] not sorted by animal key", i)
+		}
+		if record.AnimalKey == prev.AnimalKey && record.Key < prev.Key {
+			t.Fatalf("catalog.ResidentRecordsByGamePlatform(NintendoSwitch)[%d] not sorted by character key", i)
+		}
+	}
+	if !foundIsabelle {
+		t.Fatal("catalog.ResidentRecordsByGamePlatform(NintendoSwitch) missing Isabelle")
+	}
+}
+
 func TestResidentRecordsByGender(t *testing.T) {
 	records := catalog.ResidentRecordsByGender(gender.Female.Key)
 	if len(records) == 0 {
@@ -509,6 +537,34 @@ func TestVillagerRecordsByGameCategory(t *testing.T) {
 	}
 }
 
+func TestVillagerRecordsByGamePlatform(t *testing.T) {
+	records := catalog.VillagerRecordsByGamePlatform(platform.Android.Key)
+	if len(records) == 0 {
+		t.Fatal("catalog.VillagerRecordsByGamePlatform(Android) returned no records")
+	}
+
+	foundAnkha := false
+	for i, record := range records {
+		if record.ID == "Cat:Ankha" {
+			foundAnkha = true
+		}
+		if i == 0 {
+			continue
+		}
+
+		prev := records[i-1]
+		if record.AnimalKey < prev.AnimalKey {
+			t.Fatalf("catalog.VillagerRecordsByGamePlatform(Android)[%d] not sorted by animal key", i)
+		}
+		if record.AnimalKey == prev.AnimalKey && record.Key < prev.Key {
+			t.Fatalf("catalog.VillagerRecordsByGamePlatform(Android)[%d] not sorted by character key", i)
+		}
+	}
+	if !foundAnkha {
+		t.Fatal("catalog.VillagerRecordsByGamePlatform(Android) missing Ankha")
+	}
+}
+
 func TestVillagerRecordsByGender(t *testing.T) {
 	records := catalog.VillagerRecordsByGender(gender.Male.Key)
 	if len(records) == 0 {
@@ -574,6 +630,9 @@ func TestRecordHelpersMissingAnimalBucket(t *testing.T) {
 	if records := catalog.ResidentRecordsByGameCategory(""); len(records) != 0 {
 		t.Fatalf("len(catalog.ResidentRecordsByGameCategory(\"\")) = %d", len(records))
 	}
+	if records := catalog.ResidentRecordsByGamePlatform(""); len(records) != 0 {
+		t.Fatalf("len(catalog.ResidentRecordsByGamePlatform(\"\")) = %d", len(records))
+	}
 	if records := catalog.ResidentRecordsByGender(""); len(records) != 0 {
 		t.Fatalf("len(catalog.ResidentRecordsByGender(\"\")) = %d", len(records))
 	}
@@ -585,6 +644,9 @@ func TestRecordHelpersMissingAnimalBucket(t *testing.T) {
 	}
 	if records := catalog.VillagerRecordsByGameCategory(""); len(records) != 0 {
 		t.Fatalf("len(catalog.VillagerRecordsByGameCategory(\"\")) = %d", len(records))
+	}
+	if records := catalog.VillagerRecordsByGamePlatform(""); len(records) != 0 {
+		t.Fatalf("len(catalog.VillagerRecordsByGamePlatform(\"\")) = %d", len(records))
 	}
 	if records := catalog.VillagerRecordsByGender(""); len(records) != 0 {
 		t.Fatalf("len(catalog.VillagerRecordsByGender(\"\")) = %d", len(records))

--- a/character.go
+++ b/character.go
@@ -153,6 +153,24 @@ func (c Character) GamesByCategory(categoryKey Key) []Game {
 	return games
 }
 
+// GamesByPlatform returns the character's game appearances on the provided
+// platform sorted into deterministic release order.
+func (c Character) GamesByPlatform(platformKey Key) []Game {
+	if platformKey == "" {
+		return nil
+	}
+
+	games := make([]Game, 0)
+	for _, game := range c.GamesByReleaseOrder() {
+		if !game.OnPlatform(platformKey) {
+			continue
+		}
+		games = append(games, game)
+	}
+
+	return games
+}
+
 // GameCategories returns the unique game categories represented across the
 // character's known game appearances in deterministic key order.
 func (c Character) GameCategories() []GameCategory {

--- a/character_test.go
+++ b/character_test.go
@@ -143,6 +143,27 @@ func TestCharacterGamesByCategory(t *testing.T) {
 	}
 }
 
+func TestCharacterGamesByPlatform(t *testing.T) {
+	games := dogcharacters.Isabelle.Character.GamesByPlatform(platform.Nintendo3DS.Key)
+	if len(games) != 2 {
+		t.Fatalf("len(%s.GamesByPlatform(%s)) = %d", dogcharacters.Isabelle.Key, platform.Nintendo3DS.Key, len(games))
+	}
+	if games[0].Key != game.NewLeaf.Key {
+		t.Fatalf("%s.GamesByPlatform(%s)[0].Key = %s", dogcharacters.Isabelle.Key, platform.Nintendo3DS.Key, games[0].Key)
+	}
+	if games[len(games)-1].Key != game.HappyHomeDesigner.Key {
+		t.Fatalf("%s.GamesByPlatform(%s)[last].Key = %s", dogcharacters.Isabelle.Key, platform.Nintendo3DS.Key, games[len(games)-1].Key)
+	}
+
+	games = dogcharacters.Isabelle.Character.GamesByPlatform(platform.Android.Key)
+	if len(games) != 1 {
+		t.Fatalf("len(%s.GamesByPlatform(%s)) = %d", dogcharacters.Isabelle.Key, platform.Android.Key, len(games))
+	}
+	if games[0].Key != game.PocketCamp.Key {
+		t.Fatalf("%s.GamesByPlatform(%s)[0].Key = %s", dogcharacters.Isabelle.Key, platform.Android.Key, games[0].Key)
+	}
+}
+
 func TestCharacterGameCategories(t *testing.T) {
 	categories := dogcharacters.Isabelle.Character.GameCategories()
 	if len(categories) != 3 {
@@ -252,6 +273,9 @@ func TestCharacterGamesWithoutKnownAppearances(t *testing.T) {
 	}
 	if len(squirrelcharacters.Shaki.Character.GamesByCategory(gamecategory.Mainline.Key)) != 0 {
 		t.Fatalf("len(%s.GamesByCategory(%s)) = %d", squirrelcharacters.Shaki.Key, gamecategory.Mainline.Key, len(squirrelcharacters.Shaki.Character.GamesByCategory(gamecategory.Mainline.Key)))
+	}
+	if len(squirrelcharacters.Shaki.Character.GamesByPlatform(platform.NintendoSwitch.Key)) != 0 {
+		t.Fatalf("len(%s.GamesByPlatform(%s)) = %d", squirrelcharacters.Shaki.Key, platform.NintendoSwitch.Key, len(squirrelcharacters.Shaki.Character.GamesByPlatform(platform.NintendoSwitch.Key)))
 	}
 	if len(squirrelcharacters.Shaki.Character.GamePlatforms()) != 0 {
 		t.Fatalf("len(%s.GamePlatforms()) = %d", squirrelcharacters.Shaki.Key, len(squirrelcharacters.Shaki.Character.GamePlatforms()))


### PR DESCRIPTION
### Description
Add platform-based character game filters on the root model and expose catalog and record helpers built on each character's owned game metadata.

### Related Issue
N/A

### Changes Made
- Added `nook.Character.GamesByPlatform` to derive platform-specific appearances from a character's canonical `[]nook.Game` data in release order.
- Added `catalog.ResidentsByGamePlatform` and `catalog.VillagersByGamePlatform` as deterministic sorted query helpers that delegate to the model method.
- Added `catalog.ResidentRecordsByGamePlatform` and `catalog.VillagerRecordsByGamePlatform` for transport-facing access to the same platform filters.
- Added tests covering model filtering, deterministic ordering, known character inclusion, and blank-key behavior.

### Screenshots (if applicable)
Not applicable.

### How to Test
1. Run `go test ./...`
2. Inspect `character.go` for `GamesByPlatform`.
3. Inspect `catalog/game.go` and `catalog/record.go` for the delegated platform filter helpers.

### Checklist
- [x] I have followed the coding style guidelines of the project.
- [x] My code passes all existing unit tests.
- [x] I have added new unit tests to cover the changes where applicable.
- [ ] I have updated the documentation to reflect the changes.
- [x] My changes do not introduce any new warnings or errors.
- [x] I have tested my changes thoroughly.

### Additional Notes
This keeps platform facts owned by the canonical game and character model data. The catalog layer only derives filtered slices from those owned values and does not add a separate platform lookup registry.
