### PR TITLE
Expose first and last game records on character records

### DIFF
--- a/catalog/record.go
+++ b/catalog/record.go
@@ -59,6 +59,7 @@ type CharacterRecord struct {
 	AnimalKey        string               `json:"animal_key"`
 	Birthday         BirthdayRecord       `json:"birthday"`
 	Code             string               `json:"code,omitempty"`
+	FirstGame        *GameRecord          `json:"first_game,omitempty"`
 	FirstReleaseDate *ReleaseDateRecord   `json:"first_release_date,omitempty"`
 	GameCategories   []GameCategoryRecord `json:"game_categories"`
 	GamePlatforms    []PlatformRecord     `json:"game_platforms"`
@@ -68,6 +69,7 @@ type CharacterRecord struct {
 	GenderKey        string               `json:"gender_key"`
 	ID               string               `json:"id"`
 	Key              string               `json:"key"`
+	LastGame         *GameRecord          `json:"last_game,omitempty"`
 	LastReleaseDate  *ReleaseDateRecord   `json:"last_release_date,omitempty"`
 	Name             LocalizedValues      `json:"name"`
 	Special          bool                 `json:"special"`
@@ -92,6 +94,15 @@ func gameRecordsOf(games []nook.Game) []GameRecord {
 		records = append(records, GameRecordOf(game))
 	}
 	return records
+}
+
+func gameRecordPointerOf(game nook.Game, ok bool) *GameRecord {
+	if !ok {
+		return nil
+	}
+
+	record := GameRecordOf(game)
+	return &record
 }
 
 func gameCategoryRecordOf(category nook.GameCategory) GameCategoryRecord {
@@ -202,6 +213,7 @@ func CharacterRecordOf(character nook.Character) CharacterRecord {
 			Month: uint8(character.Birthday.Month),
 		},
 		Code:             character.Code.Value,
+		FirstGame:        gameRecordPointerOf(character.FirstGame()),
 		FirstReleaseDate: releaseDateRecordPointerOf(character.FirstReleaseDate()),
 		GameCategories:   gameCategoryRecordsOf(character.GameCategories()),
 		GamePlatforms:    platformRecordsOf(character.GamePlatforms()),
@@ -211,6 +223,7 @@ func CharacterRecordOf(character nook.Character) CharacterRecord {
 		GenderKey:        string(character.Gender.Key),
 		ID:               string(character.ID()),
 		Key:              string(character.Key),
+		LastGame:         gameRecordPointerOf(character.LastGame()),
 		LastReleaseDate:  releaseDateRecordPointerOf(character.LastReleaseDate()),
 		Name:             LocalizedValuesOf(character.Name),
 		Special:          character.Special,

--- a/catalog/record_test.go
+++ b/catalog/record_test.go
@@ -83,6 +83,12 @@ func TestCharacterRecordOf(t *testing.T) {
 	if record.Name[language.AmericanEnglish.String()] != "Ankha" {
 		t.Fatalf("catalog.CharacterRecordOf(cat.Ankha).Name[en-US] = %s", record.Name[language.AmericanEnglish.String()])
 	}
+	if record.FirstGame == nil {
+		t.Fatal("catalog.CharacterRecordOf(cat.Ankha).FirstGame unexpectedly nil")
+	}
+	if record.FirstGame.Key != string(game.DoubutsuNoMoriPlus.Key) {
+		t.Fatalf("catalog.CharacterRecordOf(cat.Ankha).FirstGame.Key = %s", record.FirstGame.Key)
+	}
 	if record.FirstReleaseDate == nil {
 		t.Fatal("catalog.CharacterRecordOf(cat.Ankha).FirstReleaseDate unexpectedly nil")
 	}
@@ -116,6 +122,12 @@ func TestCharacterRecordOf(t *testing.T) {
 	if record.Games[len(record.Games)-1].Key != string(game.NewHorizons.Key) {
 		t.Fatalf("catalog.CharacterRecordOf(cat.Ankha).Games[last].Key = %s", record.Games[len(record.Games)-1].Key)
 	}
+	if record.LastGame == nil {
+		t.Fatal("catalog.CharacterRecordOf(cat.Ankha).LastGame unexpectedly nil")
+	}
+	if record.LastGame.Key != string(game.NewHorizons.Key) {
+		t.Fatalf("catalog.CharacterRecordOf(cat.Ankha).LastGame.Key = %s", record.LastGame.Key)
+	}
 	if record.LastReleaseDate == nil {
 		t.Fatal("catalog.CharacterRecordOf(cat.Ankha).LastReleaseDate unexpectedly nil")
 	}
@@ -127,6 +139,9 @@ func TestCharacterRecordOf(t *testing.T) {
 func TestCharacterRecordOfWithoutReleaseDates(t *testing.T) {
 	record := catalog.CharacterRecordOf(squirrel.Shaki.Character)
 
+	if record.FirstGame != nil {
+		t.Fatalf("catalog.CharacterRecordOf(squirrel.Shaki).FirstGame = %#v", record.FirstGame)
+	}
 	if record.FirstReleaseDate != nil {
 		t.Fatalf("catalog.CharacterRecordOf(squirrel.Shaki).FirstReleaseDate = %#v", record.FirstReleaseDate)
 	}
@@ -138,6 +153,9 @@ func TestCharacterRecordOfWithoutReleaseDates(t *testing.T) {
 	}
 	if len(record.GameRegions) != 0 {
 		t.Fatalf("len(catalog.CharacterRecordOf(squirrel.Shaki).GameRegions) = %d", len(record.GameRegions))
+	}
+	if record.LastGame != nil {
+		t.Fatalf("catalog.CharacterRecordOf(squirrel.Shaki).LastGame = %#v", record.LastGame)
 	}
 	if record.LastReleaseDate != nil {
 		t.Fatalf("catalog.CharacterRecordOf(squirrel.Shaki).LastReleaseDate = %#v", record.LastReleaseDate)


### PR DESCRIPTION
### Description
Expose first and last game records directly on character transport records so downstream callers can consume appearance summaries without inferring them from the full games slice.

### Related Issue
N/A

### Changes Made
- Added `first_game` and `last_game` fields to `catalog.CharacterRecord`.
- Reused the domain model's existing `FirstGame` and `LastGame` methods to populate those fields.
- Added tests covering populated appearance summaries for known characters and nil behavior for characters without known appearances.

### Screenshots (if applicable)
Not applicable.

### How to Test
1. Run `go test ./...`
2. Inspect `catalog/record.go` for the new `first_game` and `last_game` fields on `CharacterRecord`.
3. Inspect `catalog/record_test.go` for populated and nil appearance summary coverage.

### Checklist
- [x] I have followed the coding style guidelines of the project.
- [x] My code passes all existing unit tests.
- [x] I have added new unit tests to cover the changes where applicable.
- [ ] I have updated the documentation to reflect the changes.
- [x] My changes do not introduce any new warnings or errors.
- [x] I have tested my changes thoroughly.

### Additional Notes
This keeps ownership in the canonical model layer. The transport record now exposes a more convenient appearance summary without introducing any new lookup tables or duplicate source data.
